### PR TITLE
Adding CLI changes, meshId is now assigned automatically

### DIFF
--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -11,7 +11,7 @@ All commands on this page support the `--help` argument, which provides informat
 
 ## aio api-manager:mesh:create
 
-Creates a new mesh based on the settings in the specified `JSON` file in your working directory. The `meshId` key value in your `JSON` file determines the name for your mesh. For more information, see [Creating a mesh].
+Creates a new mesh based on the settings in the specified `JSON` file in your working directory. After creating your mesh, you will receive a  `meshId`, like `continuing-aqua-bobby-2pUkDmZd`, to refer to it in the future. For more information, see [Creating a mesh].
 
 ### Usage
 
@@ -37,16 +37,12 @@ Selecting your organization as: my-organization-name
 Initialized user login and the selected organization
 OrgCode - createMesh: 27E41B3246BEC9B16E398115@MyOrg
 here
-Successfully created a mesh with the ID: meshId1234 and imsOrgCode: 27E41B3246BEC9B16E398115@MyOrg
+Successfully created a mesh with the ID: continuing-aqua-bobby-2pUkDmZd and imsOrgCode: 27E41B3246BEC9B16E398115@MyOrg
 ```
 
 ## aio api-manager:mesh:update
 
 Updates an existing mesh based on the settings in the specified `JSON` file. For more information, see [Updating a mesh].
-
-<InlineAlert variant="info" slots="text"/>
-
-You cannot modify the `meshId` when updating a mesh.
 
 ### Usage
 
@@ -72,7 +68,7 @@ Selecting your organization as: my-organization-name
 Initialized user login and the selected organization
 OrgCode - updateMesh: 27E41B3246BEC9B16E398115@MyOrg
 204
-Successfully updated the mesh with the id: meshId1234
+Successfully updated the mesh with the id: continuing-aqua-bobby-2pUkDmZd
 ```
 
 ## aio api-manager:mesh:get
@@ -92,7 +88,7 @@ aio api-manager:mesh:get [MESHID]
 ### Example
 
 ```bash
-aio api-manager:mesh:get meshId1234
+aio api-manager:mesh:get continuing-aqua-bobby-2pUkDmZd
 ```
 
 #### Response
@@ -103,7 +99,7 @@ Selecting your organization as: my-organization-name
 Initialized user login and the selected organization
 OrgCode - getMesh: 27E41B3246BEC9B16E398115@MyOrg
 Config : [object Object]
-{"imsOrgId":"27E41B3246BEC9B16E398115@MyOrg","lastUpdated":"1234123412341","meshConfig":{"sources":[{"name":"Commerce","handler":{"graphql":{"endpoint":"https://<your_commerce_site>/graphql/"}}},{"name":"AEM","handler":{"graphql":{"endpoint":"https://<your_AEM_site>/endpoint.json"}}},{"name":"LiveSearch","handler":{"graphql":{"endpoint":"https://<your_commerce_site>/search/graphql","operationHeaders":{"Magento-Store-View-Code":"default","Magento-Website-Code":"base","Magento-Store-Code":"main_website_store","Magento-Environment-Id":"<your_environment_id>","x-api-key":"search_gql","Content-Type":"application/json"},"schemaHeaders":{"Magento-Store-View-Code":"default","Magento-Website-Code":"base","Magento-Store-Code":"main_website_store","Magento-Environment-Id":"<your_environment_id>","x-api-key":"search_gql","Content-Type":"application/json"}}}}]},"meshId":"meshId1234","lastUpdatedBy":{"firstName":"User","lastName":"Name","userEmail":"uname@domain.com","userId":"undefined","displayName":"User%20Name"}}
+{"imsOrgId":"27E41B3246BEC9B16E398115@MyOrg","lastUpdated":"1234123412341","meshConfig":{"sources":[{"name":"Commerce","handler":{"graphql":{"endpoint":"https://<your_commerce_site>/graphql/"}}},{"name":"AEM","handler":{"graphql":{"endpoint":"https://<your_AEM_site>/endpoint.json"}}},{"name":"LiveSearch","handler":{"graphql":{"endpoint":"https://<your_commerce_site>/search/graphql","operationHeaders":{"Magento-Store-View-Code":"default","Magento-Website-Code":"base","Magento-Store-Code":"main_website_store","Magento-Environment-Id":"<your_environment_id>","x-api-key":"search_gql","Content-Type":"application/json"},"schemaHeaders":{"Magento-Store-View-Code":"default","Magento-Website-Code":"base","Magento-Store-Code":"main_website_store","Magento-Environment-Id":"<your_environment_id>","x-api-key":"search_gql","Content-Type":"application/json"}}}}]},"meshId":"continuing-aqua-bobby-2pUkDmZd","lastUpdatedBy":{"firstName":"User","lastName":"Name","userEmail":"uname@domain.com","userId":"undefined","displayName":"User%20Name"}}
 ```
 
 <!-- Link Definitions -->

--- a/src/pages/gateway/create-mesh.md
+++ b/src/pages/gateway/create-mesh.md
@@ -5,7 +5,7 @@ description: Create a configuration file for your mesh, access the gateway, and 
 
 # Create a mesh
 
-1. Create and save a JSON configuration file that defines the properties of your mesh. Your mesh is defined by a combination of [handlers] and [transforms]. In this example, the file name is `mesh.json`. The `meshId` is the case-sensitive name you want to assign to your mesh configuration.
+1. Create and save a JSON configuration file that defines the properties of your mesh. Your mesh is defined by a combination of [handlers] and [transforms]. In this example, the file name is `mesh.json`.
 
     **NOTE:** The following example adds both an Adobe Commerce instance (with Live Search enabled) and an Adobe Experience Manager instance to the mesh. The GraphQL endpoints for Commerce and Live Search are different, therefore you must configure them separately.
 
@@ -55,7 +55,6 @@ description: Create a configuration file for your mesh, access the gateway, and 
               }
             ]
           },
-        "meshId": "<your_mesh_Id>"
       }
   ```
 
@@ -75,6 +74,8 @@ description: Create a configuration file for your mesh, access the gateway, and 
 
 When creating or updating a mesh, the file to upload must have the `.json` filename extension.
 
+1. Select the project and workspace that you want to create the mesh in. You will be assigned a `meshId`, which is the case-sensitive, readable name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `continuing-aqua-bobby-2pUkDmZd`
+
 ## Access the gateway
 
 After creating a mesh, you should be able to access the GraphQL endpoint by entering the following URL in any GraphQL browser:
@@ -88,8 +89,6 @@ If you make any changes to your mesh file, such as adding [transforms], you must
 ```bash
 aio api-manager:mesh:update meshId update-mesh.json
 ```
-
-When updating a mesh, do not include a meshId in your mesh `JSON` file. Compare the following example to the previous [Creating a mesh](#creating_a_mesh) example on this page and note the absence of the `meshId`.
 
 ```json
     {

--- a/src/pages/gateway/headers.md
+++ b/src/pages/gateway/headers.md
@@ -47,7 +47,6 @@ Header variables are not supported in the mesh file.
       }
     ]
   },
-  "meshId": "<your_mesh_id>"
 }
 ```
 

--- a/src/pages/gateway/source-handlers.md
+++ b/src/pages/gateway/source-handlers.md
@@ -40,7 +40,6 @@ The [OpenAPI] handler allows you to connect to an OpenAPI-complaint REST service
       }
     ]
   },
-  "meshId": "<your_mesh_id>"
 }
 ```
 
@@ -86,7 +85,6 @@ The [GraphQL] handler allows you to connect to a GraphQL endpoint.
       }
     ]
   },
-  "meshId": "<your_mesh_id>"
 }
 ```
 
@@ -135,7 +133,6 @@ The `JsonSchema` source in GraphQL Mesh uses a different capitalization scheme t
           }
       ]
   },
-  "meshId": "<your_mesh_id>"
 }
 ```
 

--- a/src/pages/gateway/transforms.md
+++ b/src/pages/gateway/transforms.md
@@ -65,7 +65,6 @@ Other [GraphQL Mesh] transforms are not supported.
       }
     ]
   },
-  "meshId": "<your_mesh_id"
 }
 ```
 
@@ -111,7 +110,6 @@ You can use [RegEx flags] to enable the use of regular expressions when renaming
       }
     ]
   },
-  "meshId": "<your_mesh_id>"
 }
 ```
 
@@ -153,7 +151,6 @@ For example, you might want to exclude deprecated queries, mutations, and types 
       }
     ]
   },
-  "meshId": "<your_mesh_id>"
 }
 ```
 
@@ -194,7 +191,6 @@ For example, you might want to exclude deprecated queries, mutations, and types 
       }
     ]
   },
-  "meshId": "<your_mesh_id>"
 }
 ```
 
@@ -227,7 +223,6 @@ For example, you might want to exclude deprecated queries, mutations, and types 
       }
     ]
   },
-  "meshId": "<your_mesh_id>"
 }
 ```
 

--- a/src/pages/reference/handlers/index.md
+++ b/src/pages/reference/handlers/index.md
@@ -32,7 +32,6 @@ The following example contains a basic mesh file with an OpenAPI source handler.
       }
     ]
   },
-  "meshId": "<your_mesh_id>"
 }
 ```
 


### PR DESCRIPTION
The CLI mesh create command now automatically assigns you a `meshId`. consequently, we no longer need to specify a `meshId` in mesh files. 