### PR TITLE
Adding branding changes in CLI

### DIFF
--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -9,14 +9,14 @@ The API Mesh for Adobe Developer App Builder CLI allows you to manage and modify
 
 All commands on this page support the `--help` argument, which provides information about the command.
 
-## aio api-manager:mesh:create
+## aio api-mesh:create
 
 Creates a new mesh based on the settings in the specified `JSON` file in your working directory. After creating your mesh, you will receive a  `meshId`, like `12a3b4c5-6d78-4012-3456-7e890fa1bcde`, to refer to it in the future. For more information, see [Creating a mesh].
 
 ### Usage
 
 ```bash
-aio api-manager:mesh:create [FILE]
+aio api-mesh:create [FILE]
 ```
 
 ### Arguments
@@ -26,7 +26,7 @@ aio api-manager:mesh:create [FILE]
 ### Example
 
 ```bash
-aio api-manager:mesh:create mesh.json
+aio api-mesh:create mesh.json
 ```
 
 #### Response
@@ -35,14 +35,14 @@ aio api-manager:mesh:create mesh.json
 Successfully created a mesh with the ID: 12a3b4c5-6d78-4012-3456-7e890fa1bcde
 ```
 
-## aio api-manager:mesh:update
+## aio api-mesh:update
 
 Updates an existing mesh based on the settings in the specified `JSON` file. For more information, see [Updating a mesh].
 
 ### Usage
 
 ```bash
-aio api-manager:mesh:update [MESHID] [FILE]
+aio api-mesh:update [MESHID] [FILE]
 ```
 
 ### Arguments
@@ -54,7 +54,7 @@ aio api-manager:mesh:update [MESHID] [FILE]
 ### Example
 
 ```bash
-aio api-manager:mesh:update mesh1 mesh.json
+aio api-mesh:update mesh1 mesh.json
 ```
 
 #### Response
@@ -63,14 +63,14 @@ aio api-manager:mesh:update mesh1 mesh.json
 Successfully updated the mesh with the id: 12a3b4c5-6d78-4012-3456-7e890fa1bcde
 ```
 
-## aio api-manager:mesh:get
+## aio api-mesh:get
 
 Retrieves the current `JSON` mesh file for the specified mesh.
 
 ### Usage
 
 ```bash
-aio api-manager:mesh:get [MESHID] [DOWNLOAD]
+aio api-mesh:get [MESHID] [DOWNLOAD]
 ```
 
 ### Arguments
@@ -82,7 +82,7 @@ aio api-manager:mesh:get [MESHID] [DOWNLOAD]
 ### Example
 
 ```bash
-aio api-manager:mesh:get 12a3b4c5-6d78-4012-3456-7e890fa1bcde
+aio api-mesh:get 12a3b4c5-6d78-4012-3456-7e890fa1bcde
 ```
 
 #### Response
@@ -145,14 +145,14 @@ Successfully retrieved mesh {
 }
 ```
 
-## aio api-manager:mesh:delete meshId
+## aio api-mesh:delete meshId
 
 Deletes the mesh from the selected workspace.
 
 ### Usage
 
 ```bash
-aio api-manager:mesh:delete [MESHID]
+aio api-mesh:delete [MESHID]
 ```
 
 ### Arguments
@@ -162,7 +162,7 @@ aio api-manager:mesh:delete [MESHID]
 ### Example
 
 ```bash
-aio api-manager:mesh:delete 12a3b4c5-6d78-4012-3456-7e890fa1bcde
+aio api-mesh:delete 12a3b4c5-6d78-4012-3456-7e890fa1bcde
 ```
 
 ### Response

--- a/src/pages/gateway/create-mesh.md
+++ b/src/pages/gateway/create-mesh.md
@@ -74,7 +74,7 @@ description: Create a configuration file for your mesh, access the gateway, and 
 
 When creating or updating a mesh, the file to upload must have the `.json` filename extension.
 
-1. Select the project and workspace that you want to create the mesh in. You will be assigned a `meshId`, which is the case-sensitive, readable name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `bright-cloud-plastic-2pUkDmZd`.
+1. Select the project and workspace that you want to create the mesh in. You will be assigned a `meshId`, which is the case-sensitive, readable name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `12a3b4c5-6d78-4012-3456-7e890fa1bcded`.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/gateway/create-mesh.md
+++ b/src/pages/gateway/create-mesh.md
@@ -67,14 +67,14 @@ description: Create a configuration file for your mesh, access the gateway, and 
 1. Run the following command to create a mesh:
 
     ```bash
-    aio api-manager:mesh:create mesh.json
+    aio api-mesh:create mesh.json
     ```
 
 <InlineAlert variant="info" slots="text"/>
 
 When creating or updating a mesh, the file to upload must have the `.json` filename extension.
 
-1. Select the project and workspace that you want to create the mesh in. You will be assigned a `meshId`, which is the case-sensitive, readable name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `12a3b4c5-6d78-4012-3456-7e890fa1bcde`.
+1. Select the project and workspace that you want to create the mesh in. You will be assigned a `meshId`, which is the case-sensitive, readable name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `bright-cloud-plastic-2pUkDmZd`.
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -91,7 +91,7 @@ After creating a mesh, you should be able to access the GraphQL endpoint by ente
 If you make any changes to your mesh file, such as adding [transforms], you must publish them before the changes will be reflected in your gateway. The following command will update the `meshId` with the settings specified in the `update-mesh.json` file.
 
 ```bash
-aio api-manager:mesh:update meshId update-mesh.json
+aio api-mesh:update meshId update-mesh.json
 ```
 
 ```json

--- a/src/pages/gateway/create-mesh.md
+++ b/src/pages/gateway/create-mesh.md
@@ -74,7 +74,7 @@ description: Create a configuration file for your mesh, access the gateway, and 
 
 When creating or updating a mesh, the file to upload must have the `.json` filename extension.
 
-1. Select the project and workspace that you want to create the mesh in. You will be assigned a `meshId`, which is the case-sensitive, readable name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `12a3b4c5-6d78-4012-3456-7e890fa1bcded`.
+1. Select the project and workspace that you want to create the mesh in. You will be assigned a `meshId`, which is the case-sensitive, readable name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `12a3b4c5-6d78-4012-3456-7e890fa1bcde`.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/gateway/getting-started.md
+++ b/src/pages/gateway/getting-started.md
@@ -32,7 +32,7 @@ You will also need to have:
 
 Once you have an Adobe IO account, you can use the CLI interface to start configuring your APIs with the schema management service. This process is optional and the CLI will run without it. However, if you want to customize your `baseUrl` or `apiKey`:
 
-1. Install the schema management plugin in your project directory:
+1. Install the [schema management plugin] in your project directory:
 
    ```bash
    aio plugins:install @adobe/api-mesh.configPath
@@ -72,5 +72,5 @@ Once you have an Adobe IO account, you can use the CLI interface to start config
 [AIO Plugin Documentation]: https://github.com/adobe/aio-cli#aio-pluginslink-plugin
 [aio CLI]: https://developer.adobe.com/runtime/docs/guides/tools/cli_install/
 [Node.js]: https://nodejs.org/en/download/
-[schema management plugin]: https://www.npmjs.com/package/@magento/api-mesh.configPath
+[schema management plugin]: https://www.npmjs.com/package/@adobe/aio-cli-plugin-api-mesh
 [create a mesh]: create-mesh.md

--- a/src/pages/gateway/getting-started.md
+++ b/src/pages/gateway/getting-started.md
@@ -28,14 +28,14 @@ You will also need to have:
 -  An API key (provided by Adobe)
 -  An API to integrate (for example, your own API, any public OpenAPI REST endpoint, or an [Adobe Experience Manager API])
 
-## Configure your environment (optional)
+## Configure your environment
 
 Once you have an Adobe IO account, you can use the CLI interface to start configuring your APIs with the schema management service. This process is optional and the CLI will run without it. However, if you want to customize your `baseUrl` or `apiKey`:
 
 1. Install the [schema management plugin] in your project directory:
 
    ```bash
-   aio plugins:install @adobe/api-mesh.configPath
+   aio plugins:install @adobe/aio-cli-plugin-api-mesh
    ```
 
 1. Create a `config.json` file in your working directory with the following parameters:

--- a/src/pages/gateway/getting-started.md
+++ b/src/pages/gateway/getting-started.md
@@ -28,14 +28,14 @@ You will also need to have:
 -  An API key (provided by Adobe)
 -  An API to integrate (for example, your own API, any public OpenAPI REST endpoint, or an [Adobe Experience Manager API])
 
-## Configure your environment
+## Configure your environment (optional)
 
-Once you have an Adobe IO account, you need to access the CLI tool to start configuring your APIs with the schema management service.
+Once you have an Adobe IO account, you can use the CLI interface to start configuring your APIs with the schema management service. This process is optional and the CLI will run without it. However, if you want to customize your `baseUrl` or `apiKey`:
 
-1. Install the [schema management plugin] in your project directory:
+1. Install the schema management plugin in your project directory:
 
    ```bash
-   aio plugins:install @adobe/aio-cli-plugin-commerce-admin
+   aio plugins:install @adobe/api-mesh.configPath
    ```
 
 1. Create a `config.json` file in your working directory with the following parameters:
@@ -50,13 +50,13 @@ Once you have an Adobe IO account, you need to access the CLI tool to start conf
 1. Run the following command to load the configuration information into API Mesh for Adobe Developer App Builder:
 
    ``` bash
-   aio config:set aio-cli-plugin-commerce-admin <path_to_config.json_file>
+   aio config:set api-mesh.configPath <path_to_config.json_file>
    ```
 
    **Example:**
 
    ``` bash
-   aio config:set aio-cli-plugin-commerce-admin ./config.json
+   aio config:set api-mesh.configPath ./config.json
    ```
 
 ## Next steps
@@ -72,5 +72,5 @@ Once you have an Adobe IO account, you need to access the CLI tool to start conf
 [AIO Plugin Documentation]: https://github.com/adobe/aio-cli#aio-pluginslink-plugin
 [aio CLI]: https://developer.adobe.com/runtime/docs/guides/tools/cli_install/
 [Node.js]: https://nodejs.org/en/download/
-[schema management plugin]: https://www.npmjs.com/package/@magento/aio-cli-plugin-commerce-admin
+[schema management plugin]: https://www.npmjs.com/package/@magento/api-mesh.configPath
 [create a mesh]: create-mesh.md

--- a/src/pages/gateway/getting-started.md
+++ b/src/pages/gateway/getting-started.md
@@ -30,13 +30,17 @@ You will also need to have:
 
 ## Configure your environment
 
-Once you have an Adobe IO account, you can use the CLI interface to start configuring your APIs with the schema management service. This process is optional and the CLI will run without it. However, if you want to customize your `baseUrl` or `apiKey`:
+Once you have an Adobe IO account, you can use the CLI interface to start configuring your APIs with the schema management service. 
 
 1. Install the [schema management plugin] in your project directory:
 
    ```bash
    aio plugins:install @adobe/aio-cli-plugin-api-mesh
    ```
+
+### Configure `baseUrl` and `apiKey`
+
+These steps are optional and the CLI will run without them. If you want to customize your `baseUrl` or `apiKey`, follow these steps:
 
 1. Create a `config.json` file in your working directory with the following parameters:
 

--- a/src/pages/gateway/getting-started.md
+++ b/src/pages/gateway/getting-started.md
@@ -30,7 +30,7 @@ You will also need to have:
 
 ## Configure your environment
 
-Once you have an Adobe IO account, you can use the CLI interface to start configuring your APIs with the schema management service. 
+Once you have an Adobe IO account, you can use the command line interface (CLI) to start configuring your APIs with the schema management service. 
 
 1. Install the [schema management plugin] in your project directory:
 


### PR DESCRIPTION
`aio api-manager:mesh:` is now `aio api-mesh:`

`aio-cli-plugin-commerce-admin` is now `api-mesh.configPath`