### PR TITLE
Adding back context headers

### DIFF
--- a/src/pages/_includes/headers.md
+++ b/src/pages/_includes/headers.md
@@ -1,4 +1,4 @@
-You can pass dynamic header values at runtime or by including them in your mesh. If you want to add headers directly to the query, see [runtime headers](/src/pages/gateway/headers/#add-or-update-headers-at-runtime).
+You can pass dynamic header values at runtime or by including them in your mesh. [Runtime headers](/src/pages/gateway/headers/#add-or-update-headers-at-runtime) describes how to add headers directly to a query.
 
 -  Expressions inside dynamic values should be in javascript.
 -  Environment variables are not supported.

--- a/src/pages/_includes/headers.md
+++ b/src/pages/_includes/headers.md
@@ -1,3 +1,4 @@
-You can pass dynamic header values at runtime or by including them in your mesh.
+You can pass dynamic header values at runtime or by including them in your mesh. If you want to add headers directly to the query, see [runtime headers](/src/pages/gateway/headers/#add-or-update-headers-at-runtime).
 
-If you want to add headers directly to the query, see [runtime headers](/src/pages/gateway/headers/#add-or-update-headers-at-runtime).
+-  Expressions inside dynamic values should be in javascript.
+-  Environment variables are not supported.

--- a/src/pages/_includes/headers.md
+++ b/src/pages/_includes/headers.md
@@ -1,4 +1,6 @@
-You can pass dynamic header values at runtime or by including them in your mesh. [Runtime headers](/src/pages/gateway/headers/#add-or-update-headers-at-runtime) describes how to add headers directly to a query.
+You can pass dynamic header values at runtime or by including them in your mesh.
+
+[Runtime headers](/src/pages/gateway/headers/#add-or-update-headers-at-runtime) describes how to add headers directly to a query.
 
 -  Expressions inside dynamic values should be in javascript.
 -  Environment variables are not supported.

--- a/src/pages/_includes/headers.md
+++ b/src/pages/_includes/headers.md
@@ -1,3 +1,3 @@
-You can pass dynamic header values at runtime. Environment variables and context values are not supported.
+You can pass dynamic header values at runtime or by including them in your mesh.
 
-For more information refer to [runtime headers](/src/pages/gateway/headers/#add-or-update-headers-at-runtime).
+If you want to add headers directly to the query, see [runtime headers](/src/pages/gateway/headers/#add-or-update-headers-at-runtime).

--- a/src/pages/gateway/headers.md
+++ b/src/pages/gateway/headers.md
@@ -52,7 +52,7 @@ Using context headers allows you to inject header values from the context into y
 
 -  [OpenAPI handlers](../reference/handlers/openapi.md#dynamic-header-values)
 -  [GraphQL handlers](../reference/handlers/graphql.md#dynamic-header-values)
--  [JSON schemas](../reference/handlers/json-schema.md#dynamic-header-values)
+-  [JSON schema handlers](../reference/handlers/json-schema.md#dynamic-header-values)
 
 ## Add or update headers at runtime
 

--- a/src/pages/gateway/headers.md
+++ b/src/pages/gateway/headers.md
@@ -75,12 +75,12 @@ Consider a scenario where the value of the `Store` header defined in the previou
 
 ### Add a header to all sources
 
-If you want to send a header to all sources in your mesh, you can replace the source handler name with `*`. For example:
+To send a header to all sources in your mesh, you can replace the source handler name with `*`. For example:
 
 -  **Key**: `GGW-SH-*-trackingId`
    -  **Value**: `new-trackingId`
 
-This can be useful for authorization, authentication, and tracking headers that could be the same across multiple sources. If you want to apply a header to all sources except one, specify that source separately. For example:
+This can be useful for authorization, authentication, and tracking headers that could be the same across multiple sources. To apply a header to all sources except one, specify that source separately. For example:
 
 -  **Key**: `GGW-SH-*-trackingId`
    -  **Value**: `new-trackingId`

--- a/src/pages/gateway/headers.md
+++ b/src/pages/gateway/headers.md
@@ -52,7 +52,7 @@ Using context headers allows you to inject header values from the context into y
 
 -  [OpenAPI handlers](../reference/handlers/openapi.md#dynamic-header-values)
 -  [GraphQL handlers](../reference/handlers/graphql.md#dynamic-header-values)
--  [JSON schemas](../reference/handlers/json-schema.md#dynamic-values)
+-  [JSON schemas](../reference/handlers/json-schema.md#dynamic-header-values)
 
 ## Add or update headers at runtime
 

--- a/src/pages/gateway/headers.md
+++ b/src/pages/gateway/headers.md
@@ -11,10 +11,6 @@ To specify request headers for your mesh, you can add them inside the `JSON` fil
 
 To add headers directly to a source handler in your mesh file, for example `mesh.json`, add the `operationHeaders` object with key value pairs for your headers. The following example defines the `Store` header for the Commerce source and multiple headers for the LiveSearch source.
 
-<InlineAlert variant="info" slots="text"/>
-
-Header variables are not supported in the mesh file.
-
 ```json
 {
   "meshConfig": {
@@ -49,6 +45,14 @@ Header variables are not supported in the mesh file.
   },
 }
 ```
+
+## Add context headers
+
+Using context headers allows you to inject header values from the context into your mesh. For examples of context headers, select one of the following:
+
+-  [OpenAPI handlers](../reference/handlers/openapi.md#dynamic-header-values)
+-  [GraphQL handlers](../reference/handlers/graphql.md#dynamic-header-values)
+-  [JSON schemas](../reference/handlers/json-schema.md#dynamic-values)
 
 ## Add or update headers at runtime
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -9,7 +9,7 @@ description: Learn about the features of API Mesh for Adobe Developer App Builde
 
 API Mesh for Adobe Developer App Builder is a decoupled API platform that enables enterprise and mid-market developers to integrate private and third-party APIs and other software interfaces with Adobe products using Adobe IO.
 
-<InlineAlert variant="info" slots="text"/>
+## What is GraphQL?
 
 GraphQL is a query language for your API that lets you query exactly the information you need and only the information you need. GraphQL Mesh allows you to use GraphQL to query multiple data sources simultaneously.
 

--- a/src/pages/reference/handlers/graphql.md
+++ b/src/pages/reference/handlers/graphql.md
@@ -33,7 +33,7 @@ You can check out our example that uses schema stitching with a PostgreSQL data 
 
 <Headers />
 
-<!-- Mesh can take dynamic values from the GraphQL Context or the environmental variables.
+Mesh can take dynamic values from the GraphQL Context or the environmental variables.
 
 The expression inside dynamic values should be as in JS.
 
@@ -76,7 +76,7 @@ The expression inside dynamic values should be as in JS.
   ]
 }
 ```
- -->
+
 ## Config API Reference
 
 -  `endpoint` (type: `String`, required) - A url or file path to your remote GraphQL endpoint.

--- a/src/pages/reference/handlers/graphql.md
+++ b/src/pages/reference/handlers/graphql.md
@@ -33,9 +33,9 @@ You can check out our example that uses schema stitching with a PostgreSQL data 
 
 <Headers />
 
-Mesh can take dynamic values from the GraphQL Context or the environmental variables.
+<!-- Mesh can take dynamic values from the GraphQL Context or the environmental variables.
 
-The expression inside dynamic values should be as in JS.
+The expression inside dynamic values should be as in JS. -->
 
 ### From Context
 
@@ -56,7 +56,7 @@ The expression inside dynamic values should be as in JS.
   ]
 }
 ```
-
+<!--
 ### From Environment Variable
 
 ```json
@@ -75,7 +75,7 @@ The expression inside dynamic values should be as in JS.
     }
   ]
 }
-```
+``` -->
 
 ## Config API Reference
 

--- a/src/pages/reference/handlers/json-schema.md
+++ b/src/pages/reference/handlers/json-schema.md
@@ -39,15 +39,14 @@ To get started, use the handler in your Mesh config file:
 
 JSON Schema handlers can also use local sources, see [Reference local file handlers](../handlers/index.md#reference-local-files-in-handlers) for more information.
 
-## Dynamic Values
+## Dynamic Header Values
 
 <Headers />
 
-Mesh can take dynamic values from the GraphQL Context or the environmental variables. If you use `mesh dev` or `mesh start`, GraphQL Context will be the incoming HTTP request.
+<!-- Mesh can take dynamic values from the GraphQL Context or the environmental variables. If you use `mesh dev` or `mesh start`, GraphQL Context will be the incoming HTTP request.
+ -->
 
-The expression inside dynamic values should be as in JS.
-
-### From Context (HTTP Header for `mesh dev` or `mesh start`)
+### From Context
 
 ```json
 {
@@ -67,7 +66,7 @@ The expression inside dynamic values should be as in JS.
 }
 ```
 
-And for `mesh dev` or `mesh start`, you can pass the value using `x-my-graphql-api-token` HTTP header.
+<!-- And for `mesh dev` or `mesh start`, you can pass the value using `x-my-graphql-api-token` HTTP header.
 
 ### From Environment Variable
 
@@ -87,7 +86,7 @@ And for `mesh dev` or `mesh start`, you can pass the value using `x-my-graphql-a
     }
   ]
 }
-```
+``` -->
 
 ### From Arguments
 

--- a/src/pages/reference/handlers/json-schema.md
+++ b/src/pages/reference/handlers/json-schema.md
@@ -43,7 +43,7 @@ JSON Schema handlers can also use local sources, see [Reference local file handl
 
 <Headers />
 
-<!-- Mesh can take dynamic values from the GraphQL Context or the environmental variables. If you use `mesh dev` or `mesh start`, GraphQL Context will be the incoming HTTP request.
+Mesh can take dynamic values from the GraphQL Context or the environmental variables. If you use `mesh dev` or `mesh start`, GraphQL Context will be the incoming HTTP request.
 
 The expression inside dynamic values should be as in JS.
 
@@ -156,7 +156,7 @@ By declaring the `responseSample`, you can use the JSON sample in the GraphQL sc
 ```
 
  For your `./jsons/MyField.response.json` file, any JSON file can be used.
- -->
+
 ## Config API Reference
 
 -  `baseUrl` (type: `String`)

--- a/src/pages/reference/handlers/json-schema.md
+++ b/src/pages/reference/handlers/json-schema.md
@@ -86,7 +86,6 @@ JSON Schema handlers can also use local sources, see [Reference local file handl
     }
   ]
 }
-``` -->
 
 ### From Arguments
 
@@ -154,8 +153,8 @@ By declaring the `responseSample`, you can use the JSON sample in the GraphQL sc
 }
 ```
 
- For your `./jsons/MyField.response.json` file, any JSON file can be used.
-
+For your `./jsons/MyField.response.json` file, any JSON file can be used.
+``` -->
 ## Config API Reference
 
 -  `baseUrl` (type: `String`)

--- a/src/pages/reference/handlers/openapi.md
+++ b/src/pages/reference/handlers/openapi.md
@@ -66,7 +66,7 @@ See example below:
 
 <Headers />
 
-<!-- Mesh can take dynamic values from the GraphQL Context or the environmental variables. If you use `mesh dev` or `mesh start`, GraphQL Context will be the incoming HTTP request.
+Mesh can take dynamic values from the GraphQL Context or the environmental variables. If you use `mesh dev` or `mesh start`, GraphQL Context will be the incoming HTTP request.
 
 The expression inside dynamic values should be as in JS.
 
@@ -112,7 +112,7 @@ And for `mesh dev` or `mesh start`, you can pass the value using `x-my-graphql-a
     }
   ]
 }
-``` -->
+```
 <!-- 
 ## Advanced cookies handling
 

--- a/src/pages/reference/handlers/openapi.md
+++ b/src/pages/reference/handlers/openapi.md
@@ -66,11 +66,9 @@ See example below:
 
 <Headers />
 
-Mesh can take dynamic values from the GraphQL Context or the environmental variables. If you use `mesh dev` or `mesh start`, GraphQL Context will be the incoming HTTP request.
+<!-- Mesh can take dynamic values from the GraphQL Context or the environmental variables. If you use `mesh dev` or `mesh start`, GraphQL Context will be the incoming HTTP request. -->
 
-The expression inside dynamic values should be as in JS.
-
-### From Context (HTTP Header for `mesh dev` or `mesh start`)
+### From Context
 
 ```json
 {
@@ -89,9 +87,7 @@ The expression inside dynamic values should be as in JS.
   ]
 }
 ```
-
-And for `mesh dev` or `mesh start`, you can pass the value using `x-my-graphql-api-token` HTTP header.
-
+<!-- 
 ### From Environmental Variable
 
 `MY_API_TOKEN` is the name of the environmental variable you have the value.
@@ -113,7 +109,7 @@ And for `mesh dev` or `mesh start`, you can pass the value using `x-my-graphql-a
   ]
 }
 ```
-<!-- 
+
 ## Advanced cookies handling
 
 When building a web application, for security reasons, cookies are often used for authentication. Mobile applications on the other end, tend to use a HTTP header.

--- a/src/pages/reference/transforms/federation.md
+++ b/src/pages/reference/transforms/federation.md
@@ -50,7 +50,7 @@ Add the following configuration to your Mesh config file:
 
 ### Add Reference Resolver as a Code File
 
-If you want to add more complex business logic, you can point to a code file that exports a resolver function.
+To add more complex business logic, you can point to a code file that exports a resolver function.
 
 ```json
 {

--- a/src/pages/reference/transforms/index.md
+++ b/src/pages/reference/transforms/index.md
@@ -121,7 +121,7 @@ Wrap is the default mode for schema manipulation transforms, because is safe and
 
 <InlineAlert variant="info" slots="text"/>
 
-"wrap" is the only approach that works with data sources that already "speaks" GraphQL, or when you want to transform at all-sources (root) level, unless you're using merger-bare. If you want to remove the possible runtime implications, consider either moving your transforms at the data source level, or opting into `merger-bare`; in order to take advantage of "bare" mode.
+"wrap" is the only approach that works with data sources that already "speaks" GraphQL, or when you want to transform at all-sources (root) level, unless you're using merger-bare. To remove the possible runtime implications, consider either moving your transforms at the data source level, or opting into `merger-bare`; in order to take advantage of "bare" mode.
 
 Example:
 


### PR DESCRIPTION
Adding back context headers, see [CEXT-591](https://jira.corp.adobe.com/browse/CEXT-591) for more info.
Implemented via [CEXT-271](https://jira.corp.adobe.com/browse/CEXT-271).

[Staged version of the doc site](https://developer-stage.adobe.com/graphql-mesh-gateway/gateway/headers/#add-context-headers).