### PR TITLE
Whitespaces in mesh names

### DIFF
--- a/src/pages/gateway/source-handlers.md
+++ b/src/pages/gateway/source-handlers.md
@@ -31,7 +31,7 @@ The [OpenAPI] handler allows you to connect to an OpenAPI-complaint REST service
   "meshConfig": {
     "sources": [
       {
-        "name": "Magento REST",
+        "name": "MagentoREST",
         "handler": {
           "openapi": {
             "source": "your_Magento_API"

--- a/src/pages/gateway/source-handlers.md
+++ b/src/pages/gateway/source-handlers.md
@@ -20,7 +20,7 @@ We will add support for additional handlers in future releases.
 
 <InlineAlert variant="warning" slots="text"/>
 
-Hyphens are disallowed in source handler names.
+Only alphanumerical characters are allowed in source handler names.
 
 ## OpenAPI
 


### PR DESCRIPTION
## Purpose of this pull request

You can not have spaces or any non-alphanumerical characters in the name. Or you will get this error:

```{"message":"Magento REST cannot contain the following characters: <whitespace>"}```

## Affected pages

- https://developer.adobe.com/graphql-mesh-gateway/gateway/source-handlers/

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-  [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-  [x] My changes follow the code style of this project.
-  [x] I have read the **CONTRIBUTING** document.
-  [x] All new and existing tests passed.
