### PR TITLE
Auto API key creation and new CLI

### DIFF
--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -7,8 +7,6 @@ description: A description of the CLI commands available for API Mesh for Adobe 
 
 The API Mesh for Adobe Developer App Builder CLI allows you to manage and modify meshes. This page covers commands exclusive to the API Mesh. For authorization and other Adobe I/O Extensible CLI commands, refer to the [Adobe IO CLI command list]. For installation instructions, refer to [Getting Started].
 
-All commands on this page support the `--help` argument, which provides information about the command.
-
 ## aio api-mesh:create
 
 Creates a new mesh based on the settings in the specified `JSON` file in your working directory. After creating your mesh, you will receive a  `meshId`, like `12a3b4c5-6d78-4012-3456-7e890fa1bcde`, to refer to it in the future. For more information, see [Creating a mesh].
@@ -22,6 +20,12 @@ aio api-mesh:create [FILE]
 ### Arguments
 
 `FILE` The JSON file that contains your mesh's handlers and transforms.
+
+### Flags
+
+`-i` or `--ignoreCache` ignores the cached organization and workspace, allowing you to create a mesh in a different workspace.
+
+`--help` provides information on the specified command
 
 ### Example
 
@@ -54,24 +58,28 @@ Mesh Endpoint: https://graph.adobe.io/api/12a3b4c5-6d78-4012-3456-7e890fa1bcde/g
 
 ## aio api-mesh:update
 
-Updates an existing mesh based on the settings in the specified `JSON` file. For more information, see [Updating a mesh].
+Updates the mesh for the workspace you select based on the settings specified in the `JSON` file. For more information, see [Updating a mesh].
 
 ### Usage
 
 ```bash
-aio api-mesh:update [MESHID] [FILE]
+aio api-mesh:update [FILE]
 ```
 
 ### Arguments
 
-`MESHID` The name of the existing meshId that you want to update.
-
 `FILE` The JSON file that contains your mesh's handlers and transforms.
+
+### Flags
+
+`-i` or `--ignoreCache` ignores the cached organization and workspace, allowing you to update a mesh in a different workspace.
+
+`--help` provides information on the specified command
 
 ### Example
 
 ```bash
-aio api-mesh:update mesh1 mesh.json
+aio api-mesh:update mesh.json
 ```
 
 #### Response
@@ -82,24 +90,28 @@ Successfully updated the mesh with the id: 12a3b4c5-6d78-4012-3456-7e890fa1bcde
 
 ## aio api-mesh:get
 
-Retrieves the current `JSON` mesh file for the specified mesh.
+Retrieves the current `JSON` mesh file for the workspace you select.
 
 ### Usage
 
 ```bash
-aio api-mesh:get [MESHID] [DOWNLOAD]
+aio api-mesh:get [DOWNLOAD]
 ```
 
 ### Arguments
-
-`MESHID` The name of the existing meshId that you want to view.
   
 `DOWNLOAD` (Optional) specify the local filename to create from the mesh.
+
+### Flags
+
+`-i` or `--ignoreCache` ignores the cached organization and workspace, allowing you to retrieve a mesh from a different workspace.
+
+`--help` provides information on the specified command
 
 ### Example
 
 ```bash
-aio api-mesh:get 12a3b4c5-6d78-4012-3456-7e890fa1bcde
+aio api-mesh:get
 ```
 
 #### Response
@@ -162,7 +174,7 @@ Successfully retrieved mesh {
 }
 ```
 
-## aio api-mesh:delete meshId
+## aio api-mesh:delete
 
 Deletes the mesh from the selected workspace and unsubscribes the API key from the API Mesh service.
 
@@ -173,17 +185,19 @@ The `aio api-mesh:delete` command does not delete the API key in case other serv
 ### Usage
 
 ```bash
-aio api-mesh:delete [MESHID]
+aio api-mesh:delete
 ```
 
-### Arguments
+### Flags
 
-  MESHID    The name of the existing meshId that you want to view.
+`-i` or `--ignoreCache` ignores the cached organization and workspace, allowing you to delete a mesh from a different workspace.
+
+`--help` provides information on the specified command
 
 ### Example
 
 ```bash
-aio api-mesh:delete 12a3b4c5-6d78-4012-3456-7e890fa1bcde
+aio api-mesh:delete
 ```
 
 ### Response
@@ -194,13 +208,18 @@ Successfully deleted 12a3b4c5-6d78-4012-3456-7e890fa1bcde
 
 ## aio api-mesh:describe
 
-Returns a list of projects. Select a project to display its organization, project, workspace, and mesh IDs.
+Describes the mesh for the selected workspace.
 
 ### Usage
 
 ```bash
 aio api-mesh:describe
 ```
+### Flags
+
+`-i` or`--ignoreCache` ignores the cached organization and workspace, allowing you to get the description of a different workspace.
+
+`--help` provides information on the specified command
 
 ### Response
 

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -32,7 +32,24 @@ aio api-mesh:create mesh.json
 #### Response
 
 ```terminal
-Successfully created a mesh with the ID: 12a3b4c5-6d78-4012-3456-7e890fa1bcde
+Successfully created mesh: 12a3b4c5-6d78-4012-3456-7e890fa1bcde
+{
+"meshConfig": {
+    "sources": [
+      {
+        "name": "Commerce",
+        "handler": {
+          "graphql": {
+            "endpoint": "https://venia.magento.com/graphql/"
+          }
+        }
+      }
+    ]
+  }
+}
+Successfully create API Key: 1234567ab8c901a2b345c67d8ef9012a
+Successfully subscribed API Key 1234567ab8c901a2b345c67d8ef9012a to API Mesh service.
+Mesh Endpoint: https://<span></span>graph.adobe.io/api/12a3b4c5-6d78-4012-3456-7e890fa1bcde/graphql?api_key=1234567ab8c901a2b345c67d8ef9012a
 ```
 
 ## aio api-mesh:update
@@ -147,7 +164,11 @@ Successfully retrieved mesh {
 
 ## aio api-mesh:delete meshId
 
-Deletes the mesh from the selected workspace.
+Deletes the mesh from the selected workspace and unsubscribes the API key from the API Mesh service.
+
+<InlineAlert variant="info" slots="text"/>
+
+The `aio api-mesh:delete` command does not delete the API key in case other services use it.
 
 ### Usage
 

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -49,7 +49,7 @@ Successfully created mesh: 12a3b4c5-6d78-4012-3456-7e890fa1bcde
 }
 Successfully create API Key: 1234567ab8c901a2b345c67d8ef9012a
 Successfully subscribed API Key 1234567ab8c901a2b345c67d8ef9012a to API Mesh service.
-Mesh Endpoint: https://<span></span>graph.adobe.io/api/12a3b4c5-6d78-4012-3456-7e890fa1bcde/graphql?api_key=1234567ab8c901a2b345c67d8ef9012a
+Mesh Endpoint: https://graph.adobe.io/api/12a3b4c5-6d78-4012-3456-7e890fa1bcde/graphql?api_key=1234567ab8c901a2b345c67d8ef9012a
 ```
 
 ## aio api-mesh:update

--- a/src/pages/gateway/create-mesh.md
+++ b/src/pages/gateway/create-mesh.md
@@ -57,13 +57,15 @@ When creating or updating a mesh, the file to upload must have the `.json` filen
     aio api-mesh:create mesh.json
     ```
 
-1. Select the project and workspace that you want to create the mesh in. If you do not have a project, see [Create a project](#create-a-project).
+1. Select the organization, project, and workspace that you want to create the mesh in. If you do not have a project, see [Create a project](#create-a-project).
 
-<InlineAlert variant="info" slots="text"/>
+  You will also need to indicate if you want to automatically select the specified organization and workspace in the future. If you answer **Yes** to either of these prompts and you want to select an organization or workspace other than the cached organization and workspace, you can use the `-i` or `-ignoreCache` flag to clear the cache and allow you to select another organization and workspace.
 
-Each workspace within a project can only have one mesh associated with it at a time.
+  **Note:** Each workspace within a project can only have one mesh associated with it at a time.
 
-The `aio api-mesh:create` response assigns you a `meshId`, which is the case-sensitive name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `12a3b4c5-6d78-4012-3456-7e890fa1bcde`.
+1. When you are prompted to confirm that you want to create a mesh, select **Yes**.
+
+  The `aio api-mesh:create` response assigns you a `meshId`, an `apiKey`, and provides a GraphQL endpoint that you can use to query your mesh.
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -132,10 +134,10 @@ The following example adds both an Adobe Commerce instance (with Live Search ena
 
 ## Update an existing mesh
 
-If you make any changes to your mesh file, such as adding [transforms], you must publish them before the changes will be reflected in your gateway. The following command will update the `meshId` with the settings specified in the `update-mesh.json` file.
+If you make any changes to your mesh file, such as adding [transforms], you must publish them before the changes will be reflected in your gateway. The following command will update the mesh in the selected workspace with the settings specified in the `update-mesh.json` file.
 
 ```bash
-aio api-mesh:update meshId update-mesh.json
+aio api-mesh:update update-mesh.json
 ```
 
 ```json
@@ -197,7 +199,7 @@ aio api-mesh:describe
 
 The command returns a list of projects. Use the arrow and enter keys to select your project and organization. Alternatively, you can type to search for your project and workspace. The console then displays details about the project.
 
-## Manually create an API Key (deprecated)
+## Manually create an API Key (optional)
 
 <InlineAlert variant="warning" slots="text"/>
 

--- a/src/pages/gateway/create-mesh.md
+++ b/src/pages/gateway/create-mesh.md
@@ -57,11 +57,21 @@ When creating or updating a mesh, the file to upload must have the `.json` filen
     aio api-mesh:create mesh.json
     ```
 
-1. Select the project and workspace that you want to create the mesh in. You will be assigned a `meshId`, which is the case-sensitive, readable name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `12a3b4c5-6d78-4012-3456-7e890fa1bcde`. If you do not have a project, see [Create a project](#create-a-project).
+1. Select the project and workspace that you want to create the mesh in. If you do not have a project, see [Create a project](#create-a-project).
 
 <InlineAlert variant="info" slots="text"/>
 
 Each workspace within a project can only have one mesh associated with it at a time.
+
+ The `aio api-mesh:create` response assigns you a `meshId`, which is the case-sensitive name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `12a3b4c5-6d78-4012-3456-7e890fa1bcde`.
+
+### Access the gateway
+
+The `aio api-mesh:create` response automatically assigns you an API key and subscribes that API key to the mesh service. You can also retrieve the API key by viewing the project in the [Adobe Developer Console].
+
+After you [create a mesh], you can access the GraphQL endpoint in any GraphQL browser by modifying the following URL: `https://graph.adobe.io/api/<meshId>/graphql?api_key=<your_apiKey>`
+
+The `aio api-mesh:create` response provides the exact url to access the gateway for your mesh.
 
 ## Mesh example
 
@@ -115,44 +125,6 @@ The following example adds both an Adobe Commerce instance (with Live Search ena
         }
     }
 ```
-
-## Create an API Key
-
-<InlineAlert variant="info" slots="text"/>
-
-Only mesh owners can create API Keys. If you do not have access to [Adobe Developer Console], contact your mesh owner.
-
-To access the gateway and perform GraphQL queries, you need to provide an API Key to authorize access to your mesh. To create your API Key:
-
-1. In [Adobe Developer Console], select the desired organization from the dropdown in the top-right corner.
-
-    ![create a project](../_images/create-project.png)
-
-1. Select an existing project or [create a new one](#create-a-project).
-
-1. Inside the project, click **Add API**.
-
-    ![add an api](../_images/add-api.png)
-
-1. Select **API Mesh for Adobe Developer App Builder** and click **Next**.
-
-    ![add an api mesh](../_images/add-api-mesh.png)
-
-1. The **Allowed Domain** field is not currently enforced. Enter any valid test domain to proceed.
-
-    ![add an allowed domain](../_images/allowed-domain.png)
-
-1. Click **Save configured API**. Copy your **API Key** from the Project Overview page.
-
-    ![api key](../_images/api-key.png)
-
-You can return to the Project Overview page whenever you need to retrieve your API Key.
-
-## Access the gateway
-
-After you [create a mesh] and [create an API Key](#create-an-api-key), you can access the GraphQL endpoint in any GraphQL browser by modifying the following URL:
-
-`https://graph.adobe.io/api/<meshId>/graphql?api_key=<your_apiKey>`
 
 ## Update an existing mesh
 
@@ -220,6 +192,42 @@ aio api-mesh:describe
 ```
 
 The command returns a list of projects. Use the arrow and enter keys to select your project and organization. Alternatively, you can type to search for your project and workspace. The console then displays details about the project.
+
+## Manually create an API Key (deprecated)
+
+<InlineAlert variant="warning" slots="text"/>
+
+API keys are now automatically generated and associated with your project as part of the mesh creation process. Use the following process if you need to manually add an API to a project.
+
+<InlineAlert variant="info" slots="text"/>
+
+Only mesh owners can create API Keys. If you do not have access to [Adobe Developer Console], contact your mesh owner.
+
+To access the gateway and perform GraphQL queries, you need to provide an API Key to authorize access to your mesh. To create your API Key:
+
+1. In [Adobe Developer Console], select the desired organization from the dropdown in the top-right corner.
+
+    ![create a project](../_images/create-project.png)
+
+1. Select an existing project or [create a new one](#create-a-project).
+
+1. Inside the project, click **Add API**.
+
+    ![add an api](../_images/add-api.png)
+
+1. Select **API Mesh for Adobe Developer App Builder** and click **Next**.
+
+    ![add an api mesh](../_images/add-api-mesh.png)
+
+1. The **Allowed Domain** field is not currently enforced. Enter any valid test domain to proceed.
+
+    ![add an allowed domain](../_images/allowed-domain.png)
+
+1. Click **Save configured API**. Copy your **API Key** from the Project Overview page.
+
+    ![api key](../_images/api-key.png)
+
+You can return to the Project Overview page whenever you need to retrieve your API Key.
 
 <!-- Link Definitions -->
 [handlers]: source-handlers.md

--- a/src/pages/gateway/create-mesh.md
+++ b/src/pages/gateway/create-mesh.md
@@ -63,7 +63,11 @@ When creating or updating a mesh, the file to upload must have the `.json` filen
 
 Each workspace within a project can only have one mesh associated with it at a time.
 
- The `aio api-mesh:create` response assigns you a `meshId`, which is the case-sensitive name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `12a3b4c5-6d78-4012-3456-7e890fa1bcde`.
+The `aio api-mesh:create` response assigns you a `meshId`, which is the case-sensitive name you will use to refer to your mesh in the future. Your assigned `meshId` will look something like this: `12a3b4c5-6d78-4012-3456-7e890fa1bcde`.
+
+<InlineAlert variant="info" slots="text"/>
+
+Refer to the [command reference] for a detailed description of `aio api-mesh:create`.
 
 ### Access the gateway
 
@@ -239,3 +243,4 @@ You can return to the Project Overview page whenever you need to retrieve your A
 [creating a templated project]: https://developer.adobe.com/developer-console/docs/guides/projects/projects-template/
 [workspaces]: https://developer.adobe.com/developer-console/docs/guides/projects/projects-template/#workspaces
 [Prerequisites]: ./getting-started.md#prerequisites
+[command reference]: ./command-reference.md#aio-api-meshcreate


### PR DESCRIPTION
## Purpose of this pull request

This pr addresses an upcoming change that will automatically create an API key and associate it with a Mesh/Project when running the `aio api-mesh:create` command. 

https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=33634&projectKey=DXEXT&view=detail&selectedIssue=CEXT-701

This PR also addresses the removal of the `MESHID` from update, delete, etc commands. The mesh is now derived from the selected project/workspace combination. 

Please review the following updated stage pages:
- [Create a Mesh](https://developer-stage.adobe.com/graphql-mesh-gateway/gateway/create-mesh/)
- [Command Reference](https://developer-stage.adobe.com/graphql-mesh-gateway/gateway/command-reference/)
