### PR TITLE
Add responseConfig compatibility note

### DIFF
--- a/src/pages/gateway/headers.md
+++ b/src/pages/gateway/headers.md
@@ -101,6 +101,10 @@ All response header names must be unique. Conflicting header names will result i
 
 Mesh owners can use the `responseConfig.headers` object to add response headers. Define each header as a key value pair.
 
+<InlineAlert variant="info" slots="text"/>
+
+[JSON schema handlers](../reference/handlers/json-schema.md) do not support `responseConfig` functionality.
+
 ``` json
     { 
       "meshConfig": { 

--- a/src/pages/gateway/headers.md
+++ b/src/pages/gateway/headers.md
@@ -101,10 +101,6 @@ All response header names must be unique. Conflicting header names will result i
 
 Mesh owners can use the `responseConfig.headers` object to add response headers. Define each header as a key value pair.
 
-<InlineAlert variant="info" slots="text"/>
-
-[JSON schema handlers](../reference/handlers/json-schema.md) do not support `responseConfig` functionality.
-
 ``` json
     { 
       "meshConfig": { 
@@ -131,6 +127,10 @@ Mesh owners can use the `responseConfig.headers` object to add response headers.
 #### Return forwarded headers
 
 The `responseConfig.headers` object also allows you to return header values from a source. The following example requests the `X-Magento-Cache-Id` and `X-Cache` headers from the Venia source.
+
+<InlineAlert variant="info" slots="text"/>
+
+[JSON schema handlers](../reference/handlers/json-schema.md) do not support `responseConfig` functionality.
 
 ```json
 {

--- a/src/pages/reference/handlers/json-schema.md
+++ b/src/pages/reference/handlers/json-schema.md
@@ -11,6 +11,10 @@ This handler allows you to load any remote REST service, and describe its reques
 
 The `JsonSchema` source in GraphQL Mesh uses a different capitalization scheme than other handlers. Using `jsonSchema` will result in an error.  
 
+<InlineAlert variant="info" slots="text"/>
+
+[JSON schema handlers](../reference/handlers/json-schema.md) do not support `responseConfig` functionality.
+
 To get started, use the handler in your Mesh config file:
 
 ```json


### PR DESCRIPTION
Added a note stating that the `responseConfig` does not work with the JSON Schema handler.

Tracked by https://jira.corp.adobe.com/browse/CEXT-918