### PR TITLE
Add source install command docs

### DIFF
--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -241,7 +241,7 @@ Mesh ID: 12a3b4c5-6d78-4012-3456-7e890fa1bcde
 
 ## aio api-mesh:source:discover
 
-Lists all available sources. Select a source to view its configuration file and copy its content to your clipboard. You can also view available sources directly in the  [api-mesh-sources](https://github.com/adobe/api-mesh-sources) repo.
+Lists all available sources. Select a source to view its configuration file and copy its content to your clipboard. You can also view available sources directly in the [api-mesh-sources](https://github.com/adobe/api-mesh-sources/tree/main/connectors) repo.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -241,11 +241,11 @@ Mesh ID: 12a3b4c5-6d78-4012-3456-7e890fa1bcde
 
 ## aio api-mesh:source:discover
 
-Lists all available sources. Select a source to view its configuration file and copy its content to your clipboard.
+Lists all available sources. Select a source to view its configuration file and copy its content to your clipboard. You can also view available sources directly in the  [api-mesh-sources](https://github.com/adobe/api-mesh-sources) repo.
 
 <InlineAlert variant="info" slots="text"/>
 
-Sources are prebuilt mesh configuration files that are formatted for a specific combination of sources. This feature is currently in development, see [Create a mesh from a source](./create-mesh.md#create-a-mesh-from-a-source) for more information.
+Sources are prebuilt mesh configuration files that are formatted for a specific combination of handlers. Each source contains a mesh configuration file designed for a specific first or third-party source. Third-parties can submit their sources as a pull request to the [api-mesh-sources](https://github.com/adobe/api-mesh-sources) repo. See [Create a mesh from a source](./create-mesh.md#create-a-mesh-from-a-source) for more information.
 
 ### Usage
 
@@ -314,7 +314,7 @@ Prints the specified source's mesh file and allows you to copy it to the clipboa
 
 <InlineAlert variant="info" slots="text"/>
 
-Sources are prebuilt mesh configuration files that are formatted for a specific combination of sources. This feature is currently in development, see [Create a mesh from a source](./create-mesh.md#create-a-mesh-from-a-source) for more information.
+Sources are prebuilt mesh configuration files that are formatted for a specific combination of handlers. Each source contains a mesh configuration file designed for a specific first or third-party source. Third-parties can submit their sources as a pull request to the [api-mesh-sources](https://github.com/adobe/api-mesh-sources) repo. See [Create a mesh from a source](./create-mesh.md#create-a-mesh-from-a-source) for more information.
 
 ### Usage
 
@@ -399,6 +399,58 @@ aio api-mesh:source:get -m -s "AEM Assets API" -s "Adobe Target API"
         }
   }
 ]
+```
+
+## aio api-mesh:source:install
+
+Updates the currently selected workspace's mesh configuration with the selected configuration from the specified source.
+
+<InlineAlert variant="info" slots="text"/>
+
+Sources are prebuilt mesh configuration files that are formatted for a specific combination of handlers. Each source contains a mesh configuration file designed for a specific first or third-party source. Third-parties can submit their sources as a pull request to the [api-mesh-sources](https://github.com/adobe/api-mesh-sources) repo. See [Create a mesh from a source](./create-mesh.md#create-a-mesh-from-a-source) for more information.
+
+### Usage
+
+```bash
+aio api-mesh:source:install "SOURCE_NAME"
+```
+
+### Flags
+
+`-v` or `--variable` specifies the values of any variables in the `variables` array in the mesh configuration file for the source.
+
+`-f` or `--variable-file` specifies a file location that contains variables to use in the mesh configuration file for the source. The file must be in `.json` format. For example:
+
+```json
+  {
+	"ENDPOINT_URL": "https://venia.magento.com/graphql"
+  }
+```
+
+`--help` provides information on the specified command.
+
+### Example
+
+```bash
+aio api-mesh:source:install "AEM Assets API"
+```
+
+With a variable:
+
+```bash
+aio api-mesh:source:install "AEM Assets API" -v ENDPOINT_URL:https://venia.magento.com/graphql
+```
+
+With a variable file:
+
+```bash
+aio api-mesh:source:install "AEM Assets API" -f documents/my_variables.json
+```
+
+### Response
+
+```bash
+Successfully updated the mesh with the id: MESH_ID
 ```
 
 <!-- Link Definitions -->

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -415,6 +415,12 @@ Sources are prebuilt mesh configuration files that are formatted for a specific 
 aio api-mesh:source:install "SOURCE_NAME"
 ```
 
+To install a specific version of a source, use the following command:
+
+```bash
+aio api-mesh:source:install "SOURCE_NAME"@source_version_number
+```
+
 ### Flags
 
 `-v` or `--variable` specifies the values of any variables in the `variables` array in the mesh configuration file for the source.
@@ -445,6 +451,12 @@ With a variable file:
 
 ```bash
 aio api-mesh:source:install "AEM Assets API" -f documents/my_variables.json
+```
+
+Install a specific version:
+
+```bash
+aio api-mesh:source:install "AEM Assets API"@0.0.1
 ```
 
 ### Response

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -319,7 +319,7 @@ Sources are prebuilt mesh configuration files that are formatted for a specific 
 ### Usage
 
 ```bash
-aio api-mesh:source:get -s "%SOURCE_NAME%"
+aio api-mesh:source:get -s "<source_name>"
 ```
 
 ### Flags
@@ -412,26 +412,30 @@ Sources are prebuilt mesh configuration files that are formatted for a specific 
 ### Usage
 
 ```bash
-aio api-mesh:source:install "SOURCE_NAME"
+aio api-mesh:source:install "<source_name>"
 ```
 
 To install a specific version of a source, use the following command:
 
 ```bash
-aio api-mesh:source:install "SOURCE_NAME"@source_version_number
+aio api-mesh:source:install "<source_name>"@source_version_number
 ```
 
-### Flags
+The two variable flags, `-v` and `-f`, described in the following section, allow you to automatically replace any of the variables defined in the source that you are installing with your own values.
 
-`-v` or `--variable` specifies the values of any variables in the `variables` array in the mesh configuration file for the source.
-
-`-f` or `--variable-file` specifies a file location that contains variables to use in the mesh configuration file for the source. The file must be in `.json` format. For example:
+When using the `-f` or `--variable-file` flag, you must specify the variables in a separate file. The following example defines the variable file formatting:
 
 ```json
 {
 "ENDPOINT_URL": "https://venia.magento.com/graphql"
 }
 ```
+
+### Flags
+
+`-v` or `--variable` specifies the values of any variables defined in the `variables` array of the mesh configuration file for the source. Use commas to separate multiple variables.
+
+`-f` or `--variable-file` specifies a file location that contains variables to use in the mesh configuration file for the source. The file must be in `.json` format.
 
 `--help` provides information on the specified command.
 

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -428,9 +428,9 @@ aio api-mesh:source:install "SOURCE_NAME"@source_version_number
 `-f` or `--variable-file` specifies a file location that contains variables to use in the mesh configuration file for the source. The file must be in `.json` format. For example:
 
 ```json
-  {
-	"ENDPOINT_URL": "https://venia.magento.com/graphql"
-  }
+{
+"ENDPOINT_URL": "https://venia.magento.com/graphql"
+}
 ```
 
 `--help` provides information on the specified command.

--- a/src/pages/gateway/create-mesh.md
+++ b/src/pages/gateway/create-mesh.md
@@ -94,7 +94,11 @@ Currently this feature serves as a way for you to quickly copy an example mesh.
 
 1. Confirm that you want to print the configuration in the console. The mesh configuration prints in your terminal and is automatically copied to your clipboard depending on your selections.
 
-1. Review the mesh configuration. When you are ready to install the mesh configuration, run the `aio api-mesh:source:install` command followed by the `"SOURCE_NAME"` you want to install.
+1. Review the mesh configuration. When you are ready to install the mesh configuration, run the `aio api-mesh:source:install` command followed by the `"<source_name>"` you want to install, for example:
+
+```bash
+aio api-mesh:source:install "AEM Assets API"
+```
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/gateway/create-mesh.md
+++ b/src/pages/gateway/create-mesh.md
@@ -78,10 +78,6 @@ Refer to the [command reference] for a detailed description of `aio api-mesh:cre
 
 ### Create a mesh from a source
 
-<InlineAlert variant="warning" slots="text"/>
-
-This feature is currently in development. The sources you can select should be used as a guide for your own meshes.
-
 The `aio api-mesh:source` commands provide several prebuilt mesh sources that you can use to create your mesh file, for example `mesh.json`. Each source contains a mesh configuration file designed for a specific first or third-party source. Third-parties can submit their sources as a pull request to the [api-mesh-sources](https://github.com/adobe/api-mesh-sources) repo. Once approved, these sources will be available for selection in the CLI.
 
 Currently this feature serves as a way for you to quickly copy an example mesh.
@@ -92,19 +88,19 @@ Currently this feature serves as a way for you to quickly copy an example mesh.
   aio api-mesh:source:discover
   ```
 
-  **Note**: Alternatively, you can use the aio [api-mesh:source:get](./command-reference.md#aio-api-meshsourceget) command if you know the source you want to select.
-
-1. Confirm that you want to copy the source.
+  **Note**: Alternatively, you can use the [aio api-mesh:source:install](./command-reference.md#aio-api-meshsourceinstall) command if you know the source you want to install.
 
 1. Use the arrow keys to select which source you want to copy and press Enter. You can use the Spacebar to select multiple sources.
 
-1. Confirm that you want to print the configuration in the console. The mesh configuration prints in your terminal and is automatically copied to your clipboard.
+1. Confirm that you want to print the configuration in the console. The mesh configuration prints in your terminal and is automatically copied to your clipboard depending on your selections.
 
-1. Create a file with a name similar to `mesh.json` and paste the copied data in that file.
+1. Review the mesh configuration. When you are ready to install the mesh configuration, run the `aio api-mesh:source:install` command followed by the `"SOURCE_NAME"` you want to install.
 
-1. Save the file.
+<InlineAlert variant="info" slots="text"/>
 
-1. Now follow the steps in the [Create a mesh](#create-a-mesh) section and use the newly created file in the `aio:api-mesh:create` command.
+Alternatively, you can use the [aio api-mesh:source:get](./command-reference.md#aio-api-meshsourceget) command to print the source in the terminal or copy the source to the clipboard.
+
+Refer to the [Command reference](command-reference.md#aio-api-meshsourceinstall) flags to learn how to replace variables in the source mesh configuration.
 
 ### Access the gateway
 

--- a/src/pages/gateway/source-handlers.md
+++ b/src/pages/gateway/source-handlers.md
@@ -108,7 +108,7 @@ The [JSON] handler allows you to load a single remote REST endpoint and define t
 
 <InlineAlert variant="warning" slots="text"/>
 
-The `JsonSchema` source in GraphQL Mesh uses a different capitalization scheme than other handlers. Using `jsonSchema` will result in an error.  
+The `JsonSchema` source in GraphQL Mesh uses a different capitalization scheme than other handlers. Using `jsonSchema` will result in an error.
 
 ```json
 {

--- a/src/pages/reference/handlers/json-schema.md
+++ b/src/pages/reference/handlers/json-schema.md
@@ -9,7 +9,7 @@ This handler allows you to load any remote REST service, and describe its reques
 
 <InlineAlert variant="warning" slots="text"/>
 
-The `JsonSchema` source in GraphQL Mesh uses a different capitalization scheme than other handlers. Using `jsonSchema` will result in an error.  
+The `JsonSchema` source in GraphQL Mesh uses a different capitalization scheme than other handlers. Using `jsonSchema` will result in an error.
 
 <InlineAlert variant="info" slots="text"/>
 


### PR DESCRIPTION
This PR adds documentation for the `aio api-mesh:source:install` added in this PR https://github.com/adobe/aio-cli-plugin-api-mesh/pull/34

Staging: 
- [Create a mesh from a source](https://developer-stage.adobe.com/graphql-mesh-gateway/gateway/create-mesh/#create-a-mesh-from-a-source)
- [Command reference - install](https://developer-stage.adobe.com/graphql-mesh-gateway/gateway/command-reference/#aio-api-meshsourceinstall)