### PR TITLE
Remove hooks page

### DIFF
--- a/src/pages/gateway/hooks.md
+++ b/src/pages/gateway/hooks.md
@@ -5,6 +5,12 @@ description: Learn how to use the Hooks transform to add hooks before and after 
 
 # Hooks transform
 
+<InlineAlert variant="info" slots="text"/>
+
+The Hooks transform is not currently available and will be added in a subsequent release.
+
+<!--
+
 The Hooks transform allows you to invoke a composable [local or remote](#local-vs-remote-functions) function on a targeted node.
 
 Some use cases for the `HooksTransform` include:
@@ -18,28 +24,22 @@ Some use cases for the `HooksTransform` include:
 <InlineAlert variant="info" slots="text"/>
 
 You cannot use hooks to modify the request or the response. In addition, we recommend that you use resolvers instead of hooks to manipulate data.
+-->
 
 <!-- link to resolvers, when available -->
 
+<!--
 Hook transforms increase processing time. Use them sparingly if processing time is important. Hooks are executed in the order you provide them, except `blocking` hooks execute before non-blocking hooks.
 
 ```ts
 interface HooksTransform {
-  /**
-   * Array of target/composer to apply before the original targets
-   */
+Array of target/composer to apply before the original targets
   before?: BeforeHooksTransformObject[];
-  /**
-   * Array of target/composer to apply after the original targets
-   */
+Array of target/composer to apply after the original targets
   after?: AfterHooksTransformObject[];
-  /**
-   * Target/composer to run before executing all the operations
-   */
+Target/composer to run before executing all the operations
   beforeAll?: BeforeAllTransformObject;
-  /**
-   * Target/composer to run after executing all the operations
-   */
+Target/composer to run after executing all the operations
   afterAll?: AfterAllTransformObject;
 }
 ```
@@ -321,3 +321,5 @@ The return signature of a composer is the same for local and remote functions.
     message: string
 }
 ```
+
+ -->


### PR DESCRIPTION
Rather than delete the hooks page, I have commented out the content on it and added a note that it will be available in a future release. This allows us to leave all the links etc in place without breaking them.

I've removed some commenting from one of the code samples, as it interfered with commenting out the other content. I will re add the comments when this page is restored.