### PR TITLE
Removing external references

### DIFF
--- a/src/pages/gateway/hooks.md
+++ b/src/pages/gateway/hooks.md
@@ -179,7 +179,7 @@ A composer can be a local function or a remote serverless function. Composer sig
 
 ### `before` and `beforeAll` hook composers
 
-`before` and `beforeAll` hook composers accept the following [arguments](https://the-guild.dev/graphql/tools/docs/resolvers#resolver-function-signature):
+`before` and `beforeAll` hook composers accept the following arguments:
 
 - `root` - The resolver's return value for this field's root or parent
 

--- a/src/pages/gateway/source-handlers.md
+++ b/src/pages/gateway/source-handlers.md
@@ -57,7 +57,7 @@ The [OpenAPI] handler allows you to connect to an OpenAPI-complaint REST service
 
 <InlineAlert variant="info" slots="text"/>
 
-For more information, see GraphQL Mesh's [OpenAPI Config API Reference]. Note that the API Mesh uses an older version of GraphQL Mesh, so settings in external documentation may not be accurate for these purposes. Additionally, only the options specified above are currently supported.
+For more information, see the [OpenAPI Config API Reference].
 
 ## GraphQL endpoints
 
@@ -100,7 +100,7 @@ The [GraphQL] handler allows you to connect to a GraphQL endpoint.
 
 <InlineAlert variant="info" slots="text"/>
 
-For more information, see GraphQL Mesh's [GraphQL Config API Reference]. Note that the API Mesh uses an older version of GraphQL Mesh, so settings in external documentation may not be accurate for these purposes. Additionally, only the options specified above are currently supported.
+For more information, see the [GraphQL Config API Reference].
 
 ## JSON schemas
 
@@ -160,7 +160,7 @@ The `JsonSchema` source in GraphQL Mesh uses a different capitalization scheme t
 
 <InlineAlert variant="info" slots="text"/>
 
-For more information, see GraphQL Mesh's [JSON Schema Config API Reference]. Note that the API Mesh uses an older version of GraphQL Mesh, so settings in external documentation may not be accurate for these purposes. Additionally, only the options specified above are currently supported.
+For more information, see the [JSON Schema Config API Reference].
 
 <!-- Link Definitions -->
 

--- a/src/pages/gateway/transforms.md
+++ b/src/pages/gateway/transforms.md
@@ -21,9 +21,7 @@ Additionally, the following transforms are available but are not fully supported
 
 -  [Encapsulate]
 -  [Federation]
--  [Hoist field](https://the-guild.dev/graphql/mesh/docs/transforms/hoist)
--  [Prune](https://the-guild.dev/graphql/mesh/docs/transforms/prune)
--  [Resolvers composition](https://the-guild.dev/graphql/mesh/docs/transforms/resolvers-composition)
+-  [Hoist field](../reference/transforms/replace-field.md#scope-hoistvalue)
 
 Other [GraphQL Mesh] transforms are not supported.
 

--- a/src/pages/reference/handlers/graphql.md
+++ b/src/pages/reference/handlers/graphql.md
@@ -23,11 +23,6 @@ This handler allows you to load remote GraphQL schemas and use them with schema-
 
 GraphQL handlers can also use local sources, see [Reference local file handlers](../handlers/index.md#reference-local-files-in-handlers) for more information.
 
-<InlineAlert variant="info" slots="text"/>
-
-You can check out our example that uses schema stitching with a PostgreSQL data source.
-[Click here to open the example on GitHub](https://github.com/Urigo/graphql-mesh/tree/master/examples/postgres-geodb)
-
 ## Headers from context
 
 ```json

--- a/src/pages/reference/handlers/index.md
+++ b/src/pages/reference/handlers/index.md
@@ -4,8 +4,6 @@ title: Handlers | API Mesh for Adobe Developer App Builder
 
 # Handlers
 
-The handler documentation was originally published by [The Guild] in their [GraphQL Mesh Docs]. We are republishing it here under the [MIT License] because the API Mesh uses an older version of GraphQL Mesh, while the documentation at that site reflects the current version. Additionally, we currently only support a limited set of handlers, transforms, and recipes.
-
 Handlers, or source handlers, allow you to define sources that provide data to your mesh. The following table specifies the handlers supported by the API Mesh and the version of each handler:
 
 | Handler Package Name | Version |
@@ -81,6 +79,4 @@ Only `JS` and `JSON` files are supported using this method.
 [GraphQL]: graphql.md
 [JSON Schemas]: json-schema.md
 [Source Handlers]: /gateway/source-handlers.md
-[The Guild]: https://www.the-guild.dev/
-[MIT License]: https://github.com/Urigo/graphql-mesh/blob/master/LICENSE#L3
 [GraphQL Mesh Docs]: https://www.graphql-mesh.com/docs/

--- a/src/pages/reference/handlers/json-schema.md
+++ b/src/pages/reference/handlers/json-schema.md
@@ -4,10 +4,6 @@ title: JSON Schema or Samples | API Mesh for Adobe Developer App Builder
 
 # JSON schema handlers
 
-<InlineAlert variant="info" slots="text"/>
-
-For a guided tutorial, please refer to ["How to: Configure Sources with no definition"](https://the-guild.dev/graphql/mesh/docs/getting-started/sources-with-no-definition).
-
 This handler allows you to load any remote REST service, and describe its request/response. With this handler, you can easily customize and control the built GraphQL schema.
 
 For more information on creating JSON schemas, refer to this [JSON schema tutorial](https://json-schema.org/learn/getting-started-step-by-step.html).

--- a/src/pages/reference/handlers/openapi.md
+++ b/src/pages/reference/handlers/openapi.md
@@ -237,21 +237,6 @@ module.exports = { resolvers }
 
 The OpenAPI handler can process OAS Callbacks as GraphQL Subscriptions. It uses your PubSub implementation to consume the data. But you have to define webhooks for individual callbacks to make it work.
 
-See [Subscriptions & Webhooks](https://the-guild.dev/graphql/mesh/docs/guides/subscriptions-webhooks) to create an endpoint to consume a webhook. You should use the callback URL as `pubSubTopic` in the webhook configuration.
-
-See our example: [Subscriptions Example with Webhooks](https://codesandbox.io/s/github/Urigo/graphql-mesh/tree/master/examples/openapi-subscriptions).
-
-## Examples
-
-Here are some examples of OpenAPI Handlers:
-
--  [JavaScript Wiki](https://codesandbox.io/s/github/Urigo/graphql-mesh/tree/master/examples/openapi-javascript-wiki)
--  [Location Weather](https://codesandbox.io/s/github/Urigo/graphql-mesh/tree/master/examples/openapi-location-weather)
--  [StackExchange](https://codesandbox.io/s/github/Urigo/graphql-mesh/tree/master/examples/openapi-stackexchange)
--  [Stripe](https://codesandbox.io/s/github/Urigo/graphql-mesh/tree/master/examples/openapi-stripe)
--  [Subscriptions Example with Webhooks](https://codesandbox.io/s/github/Urigo/graphql-mesh/tree/master/examples/openapi-subscriptions)
--  [Youtrack](https://codesandbox.io/s/github/Urigo/graphql-mesh/tree/master/examples/openapi-youtrack)
-
 ## Config API Reference
 
 -  `source` (type: `Any`, required) - A pointer to your API source - could be a local file, remote file, or url endpoint

--- a/src/pages/reference/index.md
+++ b/src/pages/reference/index.md
@@ -5,9 +5,7 @@ description: Versioned documentation republished from the GraphQL Mesh documenta
 
 # GraphQL Mesh documentation
 
-This reference documentation was originally published by [The Guild] in their [GraphQL Mesh Docs]. API Mesh for Adobe Developer App Builder uses the GraphQL Mesh library. You can use the documentation in this section to customize your mesh as needed.
-
-We are republishing the GraphQL Mesh documentation here under the [MIT License] because the API Mesh uses an older version of GraphQL Mesh, while the documentation on their site only reflects the current version. Additionally, we currently only support a limited set of handlers, transforms, and recipes.
+This reference documentation uses some information from [The Guild] and their [GraphQL Mesh Docs]. Use the documentation in this section to customize your mesh as needed.
 
 Follow the links below for more information on using GraphQL Mesh:
 

--- a/src/pages/reference/transforms/index.md
+++ b/src/pages/reference/transforms/index.md
@@ -4,8 +4,6 @@ title: Transforms | API Mesh for Adobe Developer App Builder
 
 # Transforms
 
-The transform documentation was originally published by [The Guild] in their [GraphQL Mesh Docs]. We are republishing it here under the [MIT License] because API Mesh for Adobe Developer App Builder uses an older version of GraphQL Mesh, while the documentation at that site reflects the current version. Additionally, we currently only support a limited set of handlers, transforms, and recipes.
-
 The following table specifies the transforms supported by the API Mesh and the version of each transform:
 
 | Transform | Version |
@@ -461,7 +459,6 @@ Example:
 ### Modes support
 
 The table below illustrates how "bare" and "wrap" modes are supported across all transforms.
-If you have use cases for which you would require to introduce either "bare" or "wrap" mode to one of the transforms, feel free to [open a feature request](https://github.com/Urigo/graphql-mesh/issues/new/choose).
 
 | Transform             | Bare | Wrap |                      Docs                      |
 | --------------------- | :--: | :--: | :--------------------------------------------: |
@@ -483,7 +480,5 @@ If you have use cases for which you would require to introduce either "bare" or 
 [rename]: rename.md
 [replaceField]: replace-field.md
 [typeMerging]: type-merging.md
-[The Guild]: https://www.the-guild.dev/
-[MIT License]: https://github.com/Urigo/graphql-mesh/blob/master/LICENSE#L3
 [Transforms]: /gateway/transforms/
 [GraphQL Mesh Docs]: https://www.graphql-mesh.com/docs/

--- a/src/pages/reference/transforms/prefix.md
+++ b/src/pages/reference/transforms/prefix.md
@@ -30,11 +30,6 @@ Add the following configuration to your Mesh config file:
 
 For information about "bare" and "wrap" modes, read the [dedicated section](/reference/transforms/index.md#two-different-modes).
 
-<InlineAlert variant="info" slots="text"/>
-
-You can check out our example that uses schema stitching with a PostgreSQL data source and prefix transform.
-[Click here to open the example on GitHub](https://github.com/Urigo/graphql-mesh/tree/master/examples/postgres-geodb)
-
 ## Config API Reference
 
 -  `mode` (type: `String` (`bare` | `wrap`)) - Specify to apply prefix transform to bare schema or by wrapping original schema


### PR DESCRIPTION
This PR removes most external references to prevent confusing customers.
This PR is a preparation ahead of revamping the `/reference/` section.