### PR TITLE
CEXT-1100 selectQueryOrMutationField is unsupported

### DIFF
--- a/src/pages/reference/handlers/openapi.md
+++ b/src/pages/reference/handlers/openapi.md
@@ -28,7 +28,7 @@ To get started, use the handler in your Mesh config file:
 <InlineAlert variant="info" slots="text"/>
 
 This handler is based on the [JSON Schema handler](json-schema.md), so its configurations also apply to the `openapi` handler.
-
+<!-- 
 ## Overriding default Query/Mutation operations
 
 By default, OpenAPI-to-GraphQL will place all GET operations into Query fields and all other operations into Mutation fields; with this option, you can manually override this process.
@@ -64,7 +64,7 @@ See the following example:
     }
   ]
 }
-```
+``` -->
 
 ## Naming convention
 


### PR DESCRIPTION
In [CEXT-1100](https://jira.corp.adobe.com/browse/CEXT-1100), an internal user noticed that the `selectQueryOrMutationField` was used in an example in the `/reference` section, but that `selectQueryOrMutationField` is unsupported by API mesh. 

In this PR, I am commenting out the section which utilizes the unavailable field.