### PR TITLE
Linking to tutorials

### DIFF
--- a/src/data/navigation/sections/gateway.js
+++ b/src/data/navigation/sections/gateway.js
@@ -61,11 +61,6 @@ module.exports = [
                 path: '/gateway/mesh_walkthrough'
             },
             {
-                title: `Tutorials (Experience League)`,
-                path: `https://experienceleague.adobe.com/docs/commerce-learn/api-mesh/getting-started-api-mesh.html`,
-                EventTarget: `_blank`
-            },
-            {
                 title: 'Release notes',
                 path: '/gateway/release-notes'
             },
@@ -73,6 +68,11 @@ module.exports = [
                 title: 'Upgrade versions',
                 path: '/gateway/upgrade'
             },
+            {
+                title: `Videos`,
+                path: `https://experienceleague.adobe.com/docs/commerce-learn/api-mesh/getting-started-api-mesh.html`,
+                EventTarget: `_blank`
+            }
         ]
     }
     ]

--- a/src/data/navigation/sections/gateway.js
+++ b/src/data/navigation/sections/gateway.js
@@ -61,6 +61,11 @@ module.exports = [
                 path: '/gateway/mesh_walkthrough'
             },
             {
+                title: `Tutorials (Experience League)`,
+                path: `https://experienceleague.adobe.com/docs/commerce-learn/api-mesh/getting-started-api-mesh.html`,
+                EventTarget: `_blank`
+            },
+            {
                 title: 'Release notes',
                 path: '/gateway/release-notes'
             },


### PR DESCRIPTION
This PR adds a link to the [API Mesh tutorials](https://experienceleague.adobe.com/docs/commerce-learn/api-mesh/getting-started-api-mesh.html) (in ExL) to the side navigation.

This link is set to open in a new window/tab to keep the user's place within the API Mesh docs using `EventTarget: '_blank'`

[Staging site](https://developer-stage.adobe.com/graphql-mesh-gateway/gateway/getting-started/)