### PR TITLE
Updating header

### DIFF
--- a/src/pages/gateway/cache-control-headers.md
+++ b/src/pages/gateway/cache-control-headers.md
@@ -65,8 +65,6 @@ When the response includes cache-control values, only the [most restrictive valu
 }
 ```
 
-
-
 <InlineAlert variant="info" slots="text"/>
 
 POST requests are not supported, and GET requests are limited to 2,048 characters.

--- a/src/pages/gateway/cache-control-headers.md
+++ b/src/pages/gateway/cache-control-headers.md
@@ -46,6 +46,11 @@ When the response includes cache-control values, only the [most restrictive valu
 ```json
 {
   "meshConfig": {
+	"responseConfig": {
+		"headers": {
+      "Cache-Control": "max-age=50,min-fresh=6,stale-if-error=20,public,must-revalidate"
+		}
+	},
     "sources": [
       {
         "name": "venia",
@@ -53,17 +58,14 @@ When the response includes cache-control values, only the [most restrictive valu
           "graphql": {
             "endpoint": "https://venia.magento.com/graphql"
           }
-        },
-        "responseConfig": {
-          "headers": [
-            "Cache-Control"
-          ]
         }
       }
     ]
   }
 }
 ```
+
+
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -152,17 +154,17 @@ Cache-control header values in your mesh configuration file take precedence over
 ```json
 {
   "meshConfig": {
+	"responseConfig": {
+		"headers": {
+      "Cache-Control": "max-age=50,min-fresh=6,stale-if-error=20,public,must-revalidate"
+		}
+	},
     "sources": [
       {
         "name": "venia",
         "handler": {
           "graphql": {
             "endpoint": "https://venia.magento.com/graphql"
-          }
-        },
-        "responseConfig": {
-          "headers": {
-            "Cache-Control": "max-age=50,min-fresh=6,stale-if-error=20,public,must-revalidate"
           }
         }
       }

--- a/src/pages/gateway/release-notes.md
+++ b/src/pages/gateway/release-notes.md
@@ -43,7 +43,7 @@ The following [breaking changes](upgrade.md) must be addressed to make previousl
 
 - [Mesh create and update time changes](upgrade.md#mesh-create-and-update-time) - The `create` and `update` processes now run asynchronously and will typically take a few seconds to process. However, complex meshes, may take longer.
 
-- [CORS formatting](upgrade.md#cors-formatting-change) - CORS headers format has changed. The `headers` object is now the `CORS` object.
+- [CORS formatting](upgrade.md#cors-formatting-change) - CORS headers format has changed.
 
 Additionally, the beta release contained two experimental features that are not supported in the GA release:
 

--- a/src/pages/gateway/upgrade.md
+++ b/src/pages/gateway/upgrade.md
@@ -82,18 +82,7 @@ Additionally, due to our new asynchronous architecture, the create/update comman
 
 ### CORS formatting change
 
-The [CORS headers](headers.md#cors-headers) format has changed. As the following examples demonstrate, the `headers` object is now the `CORS` object.
-
-**Previous format**
-
-```json
-...
-  "responseConfig": {
-    "headers": {
-    ...
-    }
-  }
-```
+The [CORS headers](headers.md#cors-headers) format has changed.
 
 **New format**
 

--- a/src/pages/gateway/upgrade.md
+++ b/src/pages/gateway/upgrade.md
@@ -82,9 +82,7 @@ Additionally, due to our new asynchronous architecture, the create/update comman
 
 ### CORS formatting change
 
-The [CORS headers](headers.md#cors-headers) format has changed.
-
-**New format**
+[CORS headers](headers.md#cors-headers) now have the following format:
 
 ```json
   "responseConfig": {


### PR DESCRIPTION
This PR updates an example that used an earlier `header` format.

Closes https://github.com/AdobeDocs/graphql-mesh-gateway/issues/98.