### PR TITLE
Header case

### DIFF
--- a/src/pages/reference/handlers/graphql.md
+++ b/src/pages/reference/handlers/graphql.md
@@ -35,6 +35,7 @@ GraphQL handlers can also use local sources, see [Reference local file handlers]
           "endpoint": "https://my-service-url/graphql",
           "operationHeaders": {
             "Authorization": "Bearer {context.headers['x-my-api-token']}"
+          // Do not use capital letters in header names.
           }
         }
       }
@@ -42,6 +43,11 @@ GraphQL handlers can also use local sources, see [Reference local file handlers]
   ]
 }
 ```
+
+<InlineAlert variant="info" slots="text"/>
+
+Header names must be in `lowercase`. `Uppercase` characters in header names are automatically converted into `lowercase`.
+
 <!--
 ### From Environment Variable
 


### PR DESCRIPTION
## Purpose of this pull request

This PR specifies that headers in GraphQL sources should be in lowercase.

## Affected pages

https://developer.adobe.com/graphql-mesh-gateway/reference/handlers/graphql/#headers-from-context