### PR TITLE
Updating `describe` command response

### DIFF
--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -9,7 +9,7 @@ The API Mesh for Adobe Developer App Builder CLI allows you to manage and modify
 
 ## aio api-mesh:create
 
-Creates a new mesh based on the settings in the specified `JSON` file in your working directory. After creating your mesh, you will receive a  `meshId`, like `12a3b4c5-6d78-4012-3456-7e890fa1bcde`, to refer to it in the future. For more information, see [Creating a mesh].
+Creates a new mesh based on the settings in the specified `JSON` file in your working directory. After creating your mesh, you will receive a `meshId`, like `12a3b4c5-6d78-4012-3456-7e890fa1bcde`, to refer to it in the future. For more information, see [Creating a mesh].
 
 ### Usage
 
@@ -92,7 +92,7 @@ aio api-mesh:status
 
 #### Response
 
-There are four possible responses that reflect the status of your mesh:
+Four possible responses reflect the status of your mesh:
 
 - Success - Your mesh was successfully created or updated.
 
@@ -257,12 +257,17 @@ aio api-mesh:describe
 ### Response
 
 ```terminal
-Successfully retrieved mesh details
+Selected organization: my-org
+Selected project: test-project
+Select workspace: Stage
+Successfully retrieved mesh details 
 
-Org ID: 123456
+Org ID: 283912345676
 Project ID: 1234567890123456789
 Workspace ID: 2345678901234567890
 Mesh ID: 12a3b4c5-6d78-4012-3456-7e890fa1bcde
+API Key: f0a3b4c56d78401234567e890fa1bcde
+Mesh Endpoint: https://graph.adobe.io/api/12a3b4c5-6d78-4012-3456-7e890fa1bcde/graphql?api_key=12a3b4c5-6d78-4012-3456-7e890fa1bcde
 ```
 
 ## aio api-mesh:source:discover
@@ -447,7 +452,7 @@ To install a specific version of a source, use the following command:
 aio api-mesh:source:install "<source_name>"@source_version_number
 ```
 
-The two variable flags, `-v` and `-f`, described in the following section, allow you to automatically replace any of the variables defined in the source that you are installing with your own values.
+The two variable flags, `-v` and `-f`, described in the following section, allow you to automatically replace any of the variables defined in the source that you are installing with your values.
 
 When using the `-f` or `--variable-file` flag, you must specify the variables in a separate file. The following example defines the variable file formatting:
 

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -262,7 +262,7 @@ Selected project: test-project
 Select workspace: Stage
 Successfully retrieved mesh details 
 
-Org ID: 283912345676
+Org ID: 123456789
 Project ID: 1234567890123456789
 Workspace ID: 2345678901234567890
 Mesh ID: 12a3b4c5-6d78-4012-3456-7e890fa1bcde

--- a/src/pages/gateway/transforms.md
+++ b/src/pages/gateway/transforms.md
@@ -228,7 +228,7 @@ For example, you might want to exclude deprecated queries, mutations, and types 
   },
 }
 ```
-
+<!-- 
 ## Hooks
 
 Adobe created the [Hooks](hooks.md) transform to allow you to invoke composable local and remote functions on a targeted node.
@@ -269,7 +269,7 @@ interface AfterHooksTransformObject {
 interface AfterAllTransformObject {
   composer: string;
 }
-```
+``` -->
 
 <!-- Link Definitions -->
 [AEM]: https://experienceleague.adobe.com/docs/experience-manager-cloud-service.html

--- a/src/pages/gateway/transforms.md
+++ b/src/pages/gateway/transforms.md
@@ -15,7 +15,7 @@ The API Mesh currently supports the following [transforms]:
 -  [Replace Field](#replace-field)
 -  [Type Merging](#type-merging)
 -  [Naming Convention](#naming-convention)
--  [Hooks](#hooks)
+<!-- -  [Hooks](#hooks) -->
 
 Additionally, the following transforms are available but are not fully supported by API Mesh at this time. This means that your mesh will accept the transform, but we have not tested the transform thoroughly and you may encounter errors. Additionally, certain transform options may be disabled due to security concerns.
 

--- a/src/pages/gateway/upgrade.md
+++ b/src/pages/gateway/upgrade.md
@@ -104,7 +104,7 @@ API Mesh now runs on updated versions of GraphQL Mesh [handlers](source-handlers
 
 1. [Select the workspace](work-with-mesh.md#select-a-project-or-workspace) that contains the mesh you want to update.
 
-1. [Retrieve](work-with-mesh.md#retrieve-a-previously-created-meshid) your previously created mesh by running the following [`get` command](command-reference.md#aio-api-meshget).
+1. [Retrieve](work-with-mesh.md#retrieve-a-previously-created-meshid-or-mesh-endpoint-url) your previously created mesh by running the following [`get` command](command-reference.md#aio-api-meshget).
 
     ```bash
     aio api-mesh:get download.json

--- a/src/pages/gateway/work-with-mesh.md
+++ b/src/pages/gateway/work-with-mesh.md
@@ -25,7 +25,7 @@ You may need to move a mesh from one workspace to another, for example from `sta
 
 1. [Select the workspace](#select-a-project-or-workspace) that contains the mesh you want to copy.
 
-1. [Retrieve](#retrieve-a-previously-created-meshid) your previously created mesh by running the following [`get` command](command-reference.md#aio-api-meshget).
+1. [Retrieve](#retrieve-a-previously-created-meshid-or-mesh-endpoint-url) your previously created mesh by running the following [`get` command](command-reference.md#aio-api-meshget).
 
     ```bash
     aio api-mesh:get download.json

--- a/src/pages/gateway/work-with-mesh.md
+++ b/src/pages/gateway/work-with-mesh.md
@@ -7,15 +7,17 @@ description: This page describes ways you can work with meshes that are not part
 
 This page describes ways you can work with meshes that contain optional processes that are not required for [mesh creation](create-mesh.md).
 
-## Retrieve a previously created `meshId`
+## Retrieve a previously created `meshId` or mesh endpoint URL
 
-If you need to retrieve a `meshId` from a previously created mesh, use the following command:
+If you need to retrieve a `meshId` or mesh endpoint URL from a previously created mesh, use the following command to display your mesh details in the console.
 
 ```bash
 aio api-mesh:describe
 ```
 
-The command returns a list of projects. Use the arrow and enter keys to select your project and organization. Alternatively, you can type to search for your project and workspace. The console then displays details about the project.
+By default, the command describes the mesh in the selected project and workspace.
+
+If no project or workspace is selected, the command returns a list of projects. Use the arrow and enter keys to select your project and organization. Alternatively, you can type to search for your project and workspace.
 
 ## Move a mesh to another workspace
 


### PR DESCRIPTION
## Purpose of this pull request

- This PR updates the response to the `aio api-mesh:describe` command on the Command Reference page.
- I have also hidden a section about `hooks` on the Transforms page.
- On the Work with your mesh page, I changed the section about retrieving a meshID to also include retrieving the mesh endpoint URL.

## Affected pages

- https://developer.adobe.com/graphql-mesh-gateway/gateway/command-reference/#aio-api-meshdescribe
- https://developer.adobe.com/graphql-mesh-gateway/gateway/transforms/#hooks
- https://developer.adobe.com/graphql-mesh-gateway/gateway/work-with-mesh/
