### PR TITLE
beforeAll hooks

### DIFF
--- a/src/data/navigation/sections/gateway.js
+++ b/src/data/navigation/sections/gateway.js
@@ -34,12 +34,6 @@ module.exports = [
             {
                 title: 'Transforms',
                 path: '/gateway/transforms',
-                pages: [
-                    {
-                        title: 'Hooks transform',
-                        path: '/gateway/hooks',
-                    },
-                ],
             },
             {
                 title: 'Headers',
@@ -67,6 +61,10 @@ module.exports = [
             {
                 title: 'Developer Tools',
                 path: '/gateway/developer-tools.md'
+            },
+            {
+                title: 'Hooks',
+                path: '/gateway/hooks',
             },
             {
                 title: 'Extend the schema with custom resolvers',

--- a/src/pages/gateway/hooks.md
+++ b/src/pages/gateway/hooks.md
@@ -17,9 +17,10 @@ Some use cases for the `Hooks` include:
 
 -  Checking for an authorization token before making a request
 
-<!-- -  Publishing events once all operations are executed
-
--  Creating a cart in a 3rd-party store when calling the `Create Cart` mutation (Adobe Commerce) -->
+<!--
+-  Publishing events once all operations are executed
+-  Creating a cart in a 3rd-party store when calling the `Create Cart` mutation (Adobe Commerce)
+-->
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -40,9 +41,11 @@ Hooks are plugins that accept the following arguments:
 }
 ```
 
-<!-- - `target` (string) - The target GraphQL node.
+<!-- 
+- `target` (string) - The target GraphQL node.
 
-    For example, `Query.availableStores` targets [`availableStores`](https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/available-stores/), which means that if the query calls `availableStores`, then the `composer` will execute. -->
+    For example, `Query.availableStores` targets [`availableStores`](https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/available-stores/), which means that if the query calls `availableStores`, then the `composer` will execute.
+-->
 
 - `composer` (string) - The local or remote file location of the function you want to execute.
   
@@ -56,11 +59,11 @@ Hooks are plugins that accept the following arguments:
 
     If blocking is `true` and the composer returns an error, all future hook executions are canceled.
 
-    <!-- and the node's `target` will not be invoked. If multiple objects use the same `target`, an unsuccessful response means that the `target` is not called for the remainder of the operation. -->
-
     If blocking is `false` and the composer returns an error, the composer will still be invoked.
 
     Blocking hooks are executed before non-blocking hooks.
+
+<!-- and the node's `target` will not be invoked. If multiple objects use the same `target`, an unsuccessful response means that the `target` is not called for the remainder of the operation. -->
 
 ## Types of hooks
 

--- a/src/pages/gateway/hooks.md
+++ b/src/pages/gateway/hooks.md
@@ -55,6 +55,7 @@ Hooks are plugins that accept the following arguments:
     The `blocking` argument allows you to stop running hooks for a query that does not receive a successful response.
 
     If blocking is `true` and the composer returns an error, all future hook executions are canceled.
+
     <!-- and the node's `target` will not be invoked. If multiple objects use the same `target`, an unsuccessful response means that the `target` is not called for the remainder of the operation. -->
 
     If blocking is `false` and the composer returns an error, the composer will still be invoked.

--- a/src/pages/gateway/hooks.md
+++ b/src/pages/gateway/hooks.md
@@ -1,17 +1,17 @@
 ---
-title: Hooks transform
-description: Learn how to use the Hooks transform to add hooks before and after querying your mesh.
+title: Hooks
+description: Learn how to use the Hooks to add hooks before and after querying your mesh.
 ---
 
-# Hooks transform
+# Hooks
 
 <InlineAlert variant="info" slots="text"/>
 
 The hooks feature is currently in development and will be expanded in future releases. Only `beforeAll` hooks are currently available.
 
-The Hooks transform allows you to invoke a composable [local or remote](#local-vs-remote-functions) function on a targeted node.
+Hooks allow you to invoke a composable [local or remote](#local-vs-remote-functions) function on a targeted node.
 
-Some use cases for the `HooksTransform` include:
+Some use cases for the `Hooks` include:
 
 -  Authenticating a user before all operations
 
@@ -25,7 +25,7 @@ Some use cases for the `HooksTransform` include:
 
 You cannot use hooks to modify the request or the response. If you want to manipulate data, we recommend that you use [custom resolvers](./extending-unified-schema.md).
 
-Hook transforms increase processing time. Use them sparingly if processing time is important. Hooks are executed in the order you provide them. However, any `blocking` hooks execute before non-blocking hooks.
+Hooks increase processing time. Use them sparingly if processing time is important. Hooks are executed in the order you provide them. However, any `blocking` hooks execute before non-blocking hooks.
 
 ## Hook arguments
 

--- a/src/pages/gateway/hooks.md
+++ b/src/pages/gateway/hooks.md
@@ -259,10 +259,6 @@ If the `composer` is a remote function, all the arguments are sent in the `POST`
 
 Due to the limitations of `JSON` serialization and de-serialization, some complex `JSON` fields inside a remote function's arguments might not function correctly over the `HTTPS` call.
 
-### Examples
-
-<CodeBlock slots="heading, code" repeat="2" languages="js, js" />
-
 #### Local composer example
 
 This simple composer checks for an authorization header before processing the query.

--- a/src/pages/gateway/hooks.md
+++ b/src/pages/gateway/hooks.md
@@ -42,7 +42,7 @@ Hooks are plugins that accept the following arguments:
 ```
 
 <!-- 
-- `target` (string) - The target GraphQL node.
+`target` (string) - The target GraphQL node.
 
     For example, `Query.availableStores` targets [`availableStores`](https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/available-stores/), which means that if the query calls `availableStores`, then the `composer` will execute.
 -->

--- a/src/pages/gateway/hooks.md
+++ b/src/pages/gateway/hooks.md
@@ -7,9 +7,7 @@ description: Learn how to use the Hooks transform to add hooks before and after 
 
 <InlineAlert variant="info" slots="text"/>
 
-The Hooks transform is not currently available and will be added in a subsequent release.
-
-<!--
+The hooks feature is currently in development and will be expanded in future releases. Only `beforeAll` hooks are currently available.
 
 The Hooks transform allows you to invoke a composable [local or remote](#local-vs-remote-functions) function on a targeted node.
 
@@ -17,60 +15,47 @@ Some use cases for the `HooksTransform` include:
 
 -  Authenticating a user before all operations
 
--  Publishing events once all operations are executed
+-  Checking for an authorization token before making a request
 
--  Creating a cart in a 3rd-party store when calling the `Create Cart` mutation (Adobe Commerce)
+<!-- -  Publishing events once all operations are executed
+
+-  Creating a cart in a 3rd-party store when calling the `Create Cart` mutation (Adobe Commerce) -->
 
 <InlineAlert variant="info" slots="text"/>
 
-You cannot use hooks to modify the request or the response. In addition, we recommend that you use resolvers instead of hooks to manipulate data.
--->
+You cannot use hooks to modify the request or the response. If you want to manipulate data, we recommend that you use [custom resolvers](./extending-unified-schema.md).
 
-<!-- link to resolvers, when available -->
-
-<!--
-Hook transforms increase processing time. Use them sparingly if processing time is important. Hooks are executed in the order you provide them, except `blocking` hooks execute before non-blocking hooks.
-
-```ts
-interface HooksTransform {
-Array of target/composer to apply before the original targets
-  before?: BeforeHooksTransformObject[];
-Array of target/composer to apply after the original targets
-  after?: AfterHooksTransformObject[];
-Target/composer to run before executing all the operations
-  beforeAll?: BeforeAllTransformObject;
-Target/composer to run after executing all the operations
-  afterAll?: AfterAllTransformObject;
-}
-```
+Hook transforms increase processing time. Use them sparingly if processing time is important. Hooks are executed in the order you provide them. However, any `blocking` hooks execute before non-blocking hooks.
 
 ## Hook arguments
 
-Hooks accept the following arguments:
+Hooks are plugins that accept the following arguments:
 
-```ts
-interface Hook {
-target: string;
-composer: string;
-blocking: boolean;
+```json
+"hooks": {
+    "beforeAll": {
+        "composer": "<Local or Remote file>",
+        "blocking": true|false
+    }
 }
 ```
 
-- `target` (string) - The target GraphQL node.
+<!-- - `target` (string) - The target GraphQL node.
 
-    For example, `Query.availableStores` targets [`availableStores`](https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/available-stores/), which means that if the query calls `availableStores`, then the `composer` will execute.
+    For example, `Query.availableStores` targets [`availableStores`](https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/available-stores/), which means that if the query calls `availableStores`, then the `composer` will execute. -->
 
-- `composer` (string) - The local or remote file location of the function you want to execute when the mesh encounters the node specified by the `target`.
+- `composer` (string) - The local or remote file location of the function you want to execute.
   
     You must add any local scripts to the mesh's [`files` array](../reference/handlers/index.md#reference-local-files-in-handlers). [Local vs remote functions](#local-vs-remote-functions) describes when to use a local or remote function.
 
-    **NOTE**: Local composer functions are limited to 30 seconds. If `blocking` is set to `true` and the function takes longer than 30 seconds, you will receive a `Timeout Error`. In such cases, consider using a [remote composer](#local-vs-remote-functions).
+    **NOTE**: Local composer functions are limited to 30 seconds. If `blocking` is set to `true` and the function takes longer than 30 seconds, you will receive a `Timeout Error`. If you repeatedly encounter this error, consider using a [remote composer](#local-vs-remote-functions).
 
 - `blocking` (boolean) - (`false` by default) Determines if the query waits for a successful return message before continuing the query.
   
-    Only the `before` and `beforeAll` hooks accept the `blocking` argument, which allows you to stop running hooks for a query that does not receive a successful response.
+    The `blocking` argument allows you to stop running hooks for a query that does not receive a successful response.
 
-    If blocking is `true` and the composer returns an error, all future hook executions are canceled and the node's `target` will not be invoked. If multiple objects use the same `target`, an unsuccessful response means that the `target` is not called for the remainder of the operation.
+    If blocking is `true` and the composer returns an error, all future hook executions are canceled.
+    <!-- and the node's `target` will not be invoked. If multiple objects use the same `target`, an unsuccessful response means that the `target` is not called for the remainder of the operation. -->
 
     If blocking is `false` and the composer returns an error, the composer will still be invoked.
 
@@ -88,13 +73,19 @@ The `beforeAll` hook allows you to insert a function before the query takes plac
 
 The `beforeAll` hook does not accept an array.
 
-```ts
-interface BeforeAllTransformObject {
-  composer: string;
-  blocking: boolean;
-}
+```json
+"plugins": [
+    {
+        "hooks": {
+            "beforeAll": {
+                "composer": "./hooks.js#checkAuthHeader",
+                "blocking": true
+            }
+        }
+    }
+],
 ```
-
+<!-- 
 ### `before`
 
 The `before` hook allows you to insert an object or array before calling the [target](#hook-arguments) resolver. If `blocking` is set to `true` and a blocking response occurs, other queries will resolve as normal.
@@ -134,7 +125,7 @@ The `afterAll` hook allows you to insert a function after the entire operation r
 interface AfterAllTransformObject {
   composer: string;
 }
-```
+``` -->
 
 ## Local vs remote functions
 
@@ -145,6 +136,7 @@ interface AfterAllTransformObject {
 Use local composers if:
 
 - The entire operation will take less than 30 seconds.
+
 - The composer logic is simple and only requires access to the headers, body, and other context objects.
 
 Avoid using local composers if:
@@ -157,6 +149,41 @@ Avoid using local composers if:
 
 - The composer uses restricted constructs, such as `setTimeout`, `setInterval`, `for`, `while`, `console`, `process`, `global`, or `throw`.
 
+Local composers require adding any local scripts to the mesh's [`files` array](../reference/handlers/index.md#reference-local-files-in-handlers).
+
+```json
+{
+  "meshConfig": {
+    "sources": [
+      {
+        "name": "MagentoMonolithApi",
+        "handler": {
+          "graphql": {
+            "endpoint": "https://venia.magento.com/graphql"
+          }
+        }
+      }
+    ],
+    "plugins": [
+      {
+        "hooks": {
+          "beforeAll": {
+            "composer": "./hooks.js#checkAuthHeader",
+            "blocking": true
+          }
+        }
+      }
+    ],
+    "files": [
+      {
+        "path": "./hooks.js",
+        "content": <FILE CONTENT>
+      }
+    ]
+  }
+}
+```
+
 ### `remote` composers
 
 If a local composer does not work or causes timeout errors, consider using a remote composer.
@@ -165,39 +192,62 @@ If a local composer does not work or causes timeout errors, consider using a rem
 
 When using `remote` composers, you could see decreased performance, because `remote` composers add a network hop.
 
-`remote` composers can use the `root`, `args`, `context`, and `info` arguments over the network. However, the serialization and deserialization of JSON data means that any complex fields or references will be lost. If the composer depends on complex fields or references, consider using a `local` composer instead.
+`remote` composers can use the `params`, `context`, and `document` arguments over the network. However, the serialization and deserialization of JSON data means that any complex fields or references will be lost. If the composer depends on complex fields or references, consider using a `local` composer instead.
 
-### Examples
+### Example
 
-- [`before` and `beforeAll` composer examples](#examples-1)
-
-- [`after` and `afterAll` composer examples](#examples-2)
+```json
+{
+  "meshConfig": {
+    "sources": [
+      {
+        "name": "MagentoMonolithApi",
+        "handler": {
+          "graphql": {
+            "endpoint": "https://venia.magento.com/graphql"
+          }
+        }
+      }
+    ],
+    "plugins": [
+      {
+        "hooks": {
+          "beforeAll": {
+            "composer": "<Remote Composer URL>",
+            "blocking": true
+          }
+        }
+      }
+    ]
+  }
+}
+```
 
 ## Creating `composers`
 
 A composer can be a local function or a remote serverless function. Composer signatures differ depending on the hook used and the location of the function.
 
-### `before` and `beforeAll` hook composers
+### `beforeAll` hooks
 
-`before` and `beforeAll` hook composers accept the following arguments:
+`beforeAll` hook composers accept the following arguments:
 
 - `root` - The resolver's return value for this field's root or parent
 
-- `args` - An object that contains all GraphQL arguments provided for this field
+- `params` - An object that contains all GraphQL arguments provided for this field
 
-    For example, when executing `query{ user(id: "4") }`, the `args` object passed to the resolver is `{ "id": "4" }`
+    For example, when executing `query{ user(id: "4") }`, the `params` object passed to the resolver is `{ "id": "4" }`
 
 - `context` - An object containing shareable fields and information to identify the request
   
     For example, `context` contains your `headers` and the `body` of the original request.
 
-- `info` - Contains information about the execution state of the query, including the field name and the path to the field from the root
+- `document` - Contains information about the execution state of the query, including the field name and the path to the field from the root
 
     This argument is optional and should only be used in advanced cases.
 
 <InlineAlert variant="info" slots="text"/>
 
-Since the `beforeAll` hook runs at the root level, `root` and `info` are empty objects (`{}`) by default.
+Since the `beforeAll` hook runs at the root level, `root` and `document` are empty objects (`{}`) by default.
 
 If the `composer` is a remote function, all the arguments are sent in the `POST` body when calling the function.
 
@@ -211,9 +261,11 @@ Due to the limitations of `JSON` serialization and de-serialization, some comple
 
 #### Local composer example
 
+This simple composer checks for an authorization header before processing the query.
+
 ```js
 module.exports = {
-  isAuth: (root, args, context, info) => {
+  isAuth: ({context}) => {
     if (!context.headers.authorization) {
       return {
         status: "ERROR",
@@ -230,28 +282,34 @@ module.exports = {
 
 #### Remote composer example
 
+This remote composer fetches your authorization token and inserts it into the `x-auth-token` header.
+
 ```js
-addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
-
-async function handleRequest(event) {
-  try {
-    const body = await event.request.json();
-    if (!body.context.headers["authorization"]) {
-      return new Response(
-        { status: "SUCCESS", message: "Unauthorized" },
-        { status: 401 }
-      );
-    }
-    return new Response(
-      { status: "SUCCESS", message: "Authorized" },
-      { status: 200 }
-    );
-  } catch (err) {
-    return new Response(err, { status: 500 });
-  }
+function getToken({ authorization = "", body = "", url = "" }) {
+  return `${authorization} - ${body} - ${url}`;
 }
-```
 
+module.exports = {
+  insertToken: ({ context }) => {
+    const { headers, request, body } = context;
+    const { authorization } = headers;
+    const { url } = request;
+
+    const authToken = getToken({ authorization, url, body });
+
+    return {
+      status: "SUCCESS",
+      message: "Authorized",
+      data: {
+        headers: {
+          "x-auth-token": authToken,
+        },
+      },
+    };
+  },
+};
+```
+<!-- 
 ### `after` and `afterAll` hook composer
 
 `after` and `afterAll` hook composers accept the following arguments:
@@ -309,7 +367,7 @@ async function publishEvent(event) {
     );
   }
 }
-```
+``` -->
 
 ### Return signatures
 
@@ -317,9 +375,7 @@ The return signature of a composer is the same for local and remote functions.
 
 ```ts
 {
-    status: "ERROR" | "SUCCESS",
-    message: string
+  status: "ERROR" | "SUCCESS",
+  message: string
 }
 ```
-
- -->

--- a/src/pages/gateway/release-notes.md
+++ b/src/pages/gateway/release-notes.md
@@ -7,6 +7,14 @@ description: This page lists changes that were made in each version of API Mesh 
 
 The following sections indicate when updates were made to API Mesh for Adobe Developer App Builder. Refer to the [Upgrade version](upgrade.md) for more information on upgrading versions.
 
+## May 16, 2023
+
+This release contains the following changes to API Mesh:
+
+### Enhancements
+
+The [`hooks` plugin](./hooks.md) allows you to invoke a composable [local or remote](./hooks.md#local-vs-remote-functions) function on a targeted node.
+
 ## May 4, 2023
 
 This release contains the following changes to API Mesh:


### PR DESCRIPTION
This PR adds `beforeAll` hooks to the documentation. Previously, `hooks` was used as a transform, but it now functions as a plugin.

Pages affected: https://developer.adobe.com/graphql-mesh-gateway/gateway/hooks/
Staging build: https://adobedocs.github.io/graphql-mesh-gateway/gateway/hooks/

Release notes: https://adobedocs.github.io/graphql-mesh-gateway/gateway/release-notes/