### PR TITLE
JsonSchema note clarification

### DIFF
--- a/src/pages/reference/handlers/json-schema.md
+++ b/src/pages/reference/handlers/json-schema.md
@@ -10,7 +10,7 @@ For more information on creating JSON schemas, refer to this [JSON schema tutori
 
 <InlineAlert variant="warning" slots="text"/>
 
-The `JsonSchema` source in GraphQL Mesh uses a different capitalization scheme than other handlers. Using `JsonSchema` will result in an error.
+The `JsonSchema` source in GraphQL Mesh uses a different capitalization scheme than other handlers. Using `jsonSchema` will result in an error.
 
 <InlineAlert variant="info" slots="text"/>
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the note on the `JsonSchema` page to correctly indicate that the `camelcase` `jsonSchema` capitalization will cause an error.

## Affected pages

https://developer.adobe.com/graphql-mesh-gateway/reference/handlers/json-schema/