### PR TITLE
Swagger limitations

### DIFF
--- a/src/pages/gateway/source-handlers.md
+++ b/src/pages/gateway/source-handlers.md
@@ -26,6 +26,10 @@ Only alphanumerical characters are allowed in source handler names.
 
 The [OpenAPI] handler allows you to connect to an OpenAPI-complaint REST service endpoint or static Swagger schemas using a `.json` or `.yaml` file.
 
+<InlineAlert variant="info" slots="text"/>
+
+When using a Swagger schema, API Mesh can only access `application/json` content from the Swagger API definition.
+
 ```json
 {
   "meshConfig": {

--- a/src/pages/reference/handlers/openapi.md
+++ b/src/pages/reference/handlers/openapi.md
@@ -6,6 +6,10 @@ title: OpenAPI | API Mesh for Adobe Developer App Builder
 
 This handler allows you to load remote or local [OpenAPI (2/3) and Swagger](https://swagger.io) schemas.
 
+<InlineAlert variant="info" slots="text"/>
+
+When using a Swagger schema, API Mesh can only access `application/json` content from the Swagger API definition.
+
 You can import it using remote/local `.json` or `.yaml`. To use a local source with an API handler, see [Reference local file handlers](index.md#reference-local-files-in-handlers) for more information.
 
 To get started, use the handler in your Mesh config file:


### PR DESCRIPTION
This PR adds a note clarifying that when using a Swagger schema,  only `application/json` content is accessible.