### PR TITLE
Fixing `replace-field` example

### DIFF
--- a/src/pages/gateway/transforms.md
+++ b/src/pages/gateway/transforms.md
@@ -171,9 +171,9 @@ For example, you might want to exclude deprecated queries, mutations, and types 
             "endpoint": "https://example2.com/graphql"
           }
         },
-          "transforms": [
-            {
-              "replaceField": {
+        "transforms": [
+          {
+            "replaceField": {
               "replacements": [
                 {
                   "from": {
@@ -182,9 +182,9 @@ For example, you might want to exclude deprecated queries, mutations, and types 
                   },
                   "to": {
                     "type": "<your_API_Response>",
-                    "field": "child",
+                    "field": "child"
+                  },
                   "scope": "hoistvalue"
-                  }
                 }
               ]
             }
@@ -192,7 +192,7 @@ For example, you might want to exclude deprecated queries, mutations, and types 
         ]
       }
     ]
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) ...

## Affected pages

https://developer.adobe.com/graphql-mesh-gateway/gateway/transforms/#replace-field

## Summary

The example on the **Transforms** page did not correctly get converted from `yaml` to `json` and the `scope` field was inadvertently misplaced.
