### PR TITLE
Aliasing release

### DIFF
--- a/src/pages/gateway/release-notes.md
+++ b/src/pages/gateway/release-notes.md
@@ -7,6 +7,15 @@ description: This page lists changes that were made in each version of API Mesh 
 
 The following sections indicate when updates were made to API Mesh for Adobe Developer App Builder. Refer to the [Upgrade version](upgrade.md) for more information on upgrading versions.
 
+## August 10, 2023
+
+This release contains the following changes to API Mesh:
+
+### Enhancements
+
+- Added support for [aliasing](./work-with-mesh.md#aliasing).
+- Added internal caching improvements. You may notice improvements to response time.
+
 ## July 31, 2023
 
 This release contains the following changes to API Mesh:

--- a/src/pages/gateway/release-notes.md
+++ b/src/pages/gateway/release-notes.md
@@ -7,7 +7,7 @@ description: This page lists changes that were made in each version of API Mesh 
 
 The following sections indicate when updates were made to API Mesh for Adobe Developer App Builder. Refer to the [Upgrade version](upgrade.md) for more information on upgrading versions.
 
-## August 10, 2023
+## August 17, 2023
 
 This release contains the following changes to API Mesh:
 

--- a/src/pages/gateway/work-with-mesh.md
+++ b/src/pages/gateway/work-with-mesh.md
@@ -166,7 +166,7 @@ In GraphQL you can use [aliasing](https://graphql.org/learn/queries/#aliases) in
 
 <InlineAlert variant="info" slots="text"/>
 
-You can also field names within your mesh by using the [`rename`](../reference/transforms/rename.md) and [`prefix`](../reference/transforms/prefix.md) transforms.
+You can also rename field names within your mesh by using the [`rename`](../reference/transforms/rename.md) and [`prefix`](../reference/transforms/prefix.md) transforms.
 
 The following example renames the `name` field to `productName`.
 

--- a/src/pages/gateway/work-with-mesh.md
+++ b/src/pages/gateway/work-with-mesh.md
@@ -159,3 +159,43 @@ For example:
 
 -  `aio config:delete console.project` Removes the current project from the cache.
 -  `aio config:delete console.workspace` Removes the current workspace from the cache.
+
+## Aliasing
+
+In GraphQL you can use aliasing to rename fields and avoid conflicts. This is particularly useful for API Mesh, because along with the [`rename`](../reference/transforms/rename.md) and [`prefix`](../reference/transforms/prefix.md) transforms it allows you to avoid naming conflicts.
+
+The following example renames the `name` field to `productName`.
+
+```graphql
+{
+ products(search:"tops"){
+   items {
+       productName:name
+       sku
+     }
+   } 
+ } 
+```
+
+Due to the limitations of API Mesh, responses contain both the newly created alias field and the originally named field. For example, the previous query produces the following response that contains both the aliased field, `productName`, and the original field, `name`.
+
+```json
+{
+  "data": {
+    "products": {
+      "CommerceItems": [
+        {
+          "productName": "Vitalia Top",
+          "sku": "VT10",
+          "name": "Vitalia Top"
+        },
+        {
+          "productName": "Jillian Top",
+          "sku": "VT12",
+          "name": "Jillian Top"
+        }
+      ]
+    }
+  }
+}
+```

--- a/src/pages/gateway/work-with-mesh.md
+++ b/src/pages/gateway/work-with-mesh.md
@@ -177,7 +177,7 @@ The following example renames the `name` field to `productName`.
  } 
 ```
 
-Due to the limitations of API Mesh, responses contain both the newly created alias field and the originally named field. For example, the previous query produces the following response that contains both the aliased field, `productName`, and the original field, `name`.
+Due to the limitations of API Mesh, responses contain both the newly created alias field and the original field. For example, the previous query produces the following response that contains both the aliased field, `productName`, and the original field, `name`.
 
 ```json
 {

--- a/src/pages/gateway/work-with-mesh.md
+++ b/src/pages/gateway/work-with-mesh.md
@@ -162,7 +162,11 @@ For example:
 
 ## Aliasing
 
-In GraphQL you can use aliasing to rename fields and avoid conflicts. This is particularly useful for API Mesh, because along with the [`rename`](../reference/transforms/rename.md) and [`prefix`](../reference/transforms/prefix.md) transforms it allows you to avoid naming conflicts.
+In GraphQL you can use [aliasing](https://graphql.org/learn/queries/#aliases) in your query to rename fields and avoid fields with conflicting names. This is particularly useful for API Mesh because aliasing allows you to rename fields when querying.
+
+<InlineAlert variant="info" slots="text"/>
+
+You can also field names within your mesh by using the [`rename`](../reference/transforms/rename.md) and [`prefix`](../reference/transforms/prefix.md) transforms.
 
 The following example renames the `name` field to `productName`.
 


### PR DESCRIPTION
This PR adds information about how aliasing in GraphQL queries works with API Mesh. It contains updates to the following pages:
- https://developer.adobe.com/graphql-mesh-gateway/gateway/work-with-mesh/
- https://developer.adobe.com/graphql-mesh-gateway/gateway/release-notes/

Staging:
- [Aliasing](https://adobedocs.github.io/graphql-mesh-gateway/gateway/work-with-mesh/#aliasing)
- [Release notes](https://adobedocs.github.io/graphql-mesh-gateway/gateway/release-notes/#august-10-2023)