### PR TITLE
Content type note

### DIFF
--- a/src/pages/gateway/source-handlers.md
+++ b/src/pages/gateway/source-handlers.md
@@ -24,11 +24,11 @@ Only alphanumerical characters are allowed in source handler names.
 
 ## OpenAPI
 
-The [OpenAPI] handler allows you to connect to an OpenAPI-complaint REST service endpoint or static Swagger schemas using a `.json` or `.yaml` file.
+The [OpenAPI] handler allows you to connect to an OpenAPI-compliant REST service endpoint or static Swagger schemas using a `.json` or `.yaml` file.
 
 <InlineAlert variant="info" slots="text"/>
 
-When using a Swagger schema, API Mesh can only access `application/json` content from the Swagger API definition.
+When using a Swagger schema, API Mesh can only access `application/json` content from the Swagger API definition. API Mesh does not accept a `/` or a wildcard (`**`) as a content type.
 
 ```json
 {

--- a/src/pages/reference/handlers/openapi.md
+++ b/src/pages/reference/handlers/openapi.md
@@ -8,7 +8,7 @@ This handler allows you to load remote or local [OpenAPI (2/3) and Swagger](http
 
 <InlineAlert variant="info" slots="text"/>
 
-When using a Swagger schema, API Mesh can only access `application/json` content from the Swagger API definition.
+When using a Swagger schema, API Mesh can only access `application/json` content from the Swagger API definition. API Mesh does not accept a `/` or a wildcard (`**`) as a content type.
 
 You can import it using remote/local `.json` or `.yaml`. To use a local source with an API handler, see [Reference local file handlers](index.md#reference-local-files-in-handlers) for more information.
 


### PR DESCRIPTION
## Purpose of this pull request

This PR adds a clarification of the accepted `content` types in the OpenAPI handler.

This change affects the following pages:
- https://developer.adobe.com/graphql-mesh-gateway/reference/handlers/openapi/
- https://developer.adobe.com/graphql-mesh-gateway/gateway/source-handlers/