### PR TITLE
CLI note

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -2,13 +2,14 @@
 title: Overview - API Mesh for Adobe Developer App Builder
 description: Learn about the features of API Mesh for Adobe Developer App Builder.
 ---
-<InlineAlert variant="warning" slots="text"/>
-
-Update to the latest API Mesh CLI package to avoid any interruptions. For more information refer to the [release notes](gateway/release-notes.md#august-30-2023).
 
 <Hero slots="image, heading, text"/>
 
 ![API Mesh](_images/home-bg.jpeg)
+
+<InlineAlert variant="warning" slots="text"/>
+
+Update to the latest API Mesh CLI package to avoid any interruptions. For more information refer to the [release notes](gateway/release-notes.md#august-30-2023).
 
 # API Mesh for Adobe Developer App Builder
 


### PR DESCRIPTION
This PR moves the CLI Note on the main index page below the `hero` image. While this rendered fine locally and on stage, I think the `hero` may be in a `<div>` which is suppressing the note.