### PR TITLE
`run` command

### DIFF
--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -80,6 +80,8 @@ The following arguments are all optional.
   }
   ```
 
+For more information on debugging, see the [`node.js` Inspector documentation.](https://nodejs.org/en/docs/inspector#inspector-clients)
+
 #### Example
 
 The following example runs the mesh locally at port `9000`.

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -48,6 +48,39 @@ The following example creates the environment in the `mesh_examples` subdirector
 Local workspace created successfully
 ```
 
+## aio api-mesh:run
+
+[Deploys a mesh locally](./developer-tools.md#deploy-a-mesh-locally). You only need to run this command if you want to work with your mesh locally for testing.
+
+### Usage
+
+```bash
+aio api-mesh:run <port_number>
+```
+
+### Flags
+
+The following arguments are all optional.
+
+`-p` or `--port` allows you to specify the port number for your local environment. The default is `5000`.
+
+`--debug` enters debug mode.
+
+#### Example
+
+The following example runs the mesh locally at port `9000`.
+
+  ```bash
+  aio api-mesh:run -p 9000
+  ```
+
+### Response
+
+```terminal
+Starting server on port no: 5000
+Data from server -
+```
+
 ## aio api-mesh:create
 
 Creates a new mesh based on the settings in the specified `JSON` file in your working directory. After creating your mesh, you will receive a `meshId`, like `12a3b4c5-6d78-4012-3456-7e890fa1bcde`, to refer to it in the future. For more information, see [Creating a mesh].

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -50,6 +50,10 @@ Local workspace created successfully
 
 ## aio api-mesh:run
 
+<InlineAlert variant="info" slots="text"/>
+
+This command is currently in beta.
+
 [Deploys a mesh locally](./developer-tools.md#create-a-local-environment). You only need to run this command if you want to work with your mesh locally for testing.
 
 ### Usage

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -59,7 +59,7 @@ This command is currently in beta.
 ### Usage
 
 ```bash
-aio api-mesh:run <port_number>
+aio api-mesh:run [FILE]
 ```
 
 ### Flags
@@ -75,13 +75,13 @@ The following arguments are all optional.
 The following example runs the mesh locally at port `9000`.
 
   ```bash
-  aio api-mesh:run -p 9000
+  aio api-mesh:run mesh.json -p 9000
   ```
 
 ### Response
 
 ```terminal
-Starting server on port no: 5000
+Starting server on port : 9000
 Data from server -
 ```
 

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -68,7 +68,7 @@ The following arguments are all optional.
 
 `-p` or `--port` allows you to specify the port number for your local environment. The default is `5000`.
 
-`--debug` enters debug mode. Debugging is disabled by default. To debug in an IDE such as Visual Studio Code, add the following configuration to your `launch.json` file:
+`--debug` enters debug mode. To debug in an IDE such as Visual Studio Code, add the following configuration to your `launch.json` file:
 
   ```json
   {

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -54,7 +54,7 @@ Local workspace created successfully
 
 This command is currently in beta.
 
-[Deploys a mesh locally](./developer-tools.md#create-a-local-environment). You only need to run this command if you want to work with your mesh locally for testing.
+[Deploys a mesh locally](./developer-tools.md#create-a-local-environment). You only need to run this command if you want to work with your mesh locally for testing. Run `aio api-mesh:init` before running this command.
 
 ### Usage
 
@@ -68,7 +68,17 @@ The following arguments are all optional.
 
 `-p` or `--port` allows you to specify the port number for your local environment. The default is `5000`.
 
-`--debug` enters debug mode.
+`--debug` enters debug mode. Debugging is disabled by default. To use debugging, add the following configuration to your `launch.json` file:
+
+  ```json
+  {
+    "name": "Debug Mesh",
+    "port": 9229,
+    "request": "attach",
+    "skipFiles": ["<node_internals>/**"],
+    "type": "node"
+  }
+  ```
 
 #### Example
 
@@ -81,8 +91,8 @@ The following example runs the mesh locally at port `9000`.
 ### Response
 
 ```terminal
-Starting server on port : 9000
-Data from server -
+Starting server on port : 5000
+Server is running on http://localhost:5000/graphql
 ```
 
 ## aio api-mesh:create

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -16,7 +16,7 @@ API Mesh for Adobe Developer App Builder CLI allows you to manage and modify mes
 
 ## aio api-mesh:init
 
-Creates a [local development environment](./developer-tools.md#initiate-a-local-environment). You only need to run this command if you want to set up a local environment.
+Creates a [local development environment](./developer-tools.md#create-a-local-environment). You only need to run this command if you want to set up a local environment.
 
 ### Usage
 

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -68,7 +68,7 @@ The following arguments are all optional.
 
 `-p` or `--port` allows you to specify the port number for your local environment. The default is `5000`.
 
-`--debug` enters debug mode. Debugging is disabled by default. To use debugging, add the following configuration to your `launch.json` file:
+`--debug` enters debug mode. Debugging is disabled by default. To debug in an IDE such as Visual Studio Code, add the following configuration to your `launch.json` file:
 
   ```json
   {

--- a/src/pages/gateway/command-reference.md
+++ b/src/pages/gateway/command-reference.md
@@ -50,7 +50,7 @@ Local workspace created successfully
 
 ## aio api-mesh:run
 
-[Deploys a mesh locally](./developer-tools.md#deploy-a-mesh-locally). You only need to run this command if you want to work with your mesh locally for testing.
+[Deploys a mesh locally](./developer-tools.md#create-a-local-environment). You only need to run this command if you want to work with your mesh locally for testing.
 
 ### Usage
 

--- a/src/pages/gateway/developer-tools.md
+++ b/src/pages/gateway/developer-tools.md
@@ -32,7 +32,15 @@ The [`aio api-mesh:init` command](./command-reference.md#aio-api-meshinit) allow
 
 1. Specify whether you want to use Node Package Manager (`npm`) or `yarn`. (Requires [`npm`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) or [`yarn`](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable).)
 
-The console indicates that the local environment installed successfully.
+  The console indicates that the local environment installed successfully.
+
+1. To deploy your mesh locally, use the `run` command. You can specify a port by using the `--port` flag or by indicating one in the `.env` file. The port defaults to `5000`.
+
+  ```terminal
+  aio api-mesh run --port 9000
+  ```
+
+  The console indicates your server status.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/gateway/developer-tools.md
+++ b/src/pages/gateway/developer-tools.md
@@ -38,13 +38,13 @@ All of these steps can be automated using flags described in the [command refere
 
   The console indicates that the local environment installed successfully.
 
-1. To deploy your mesh locally, use the `run` command. You can specify a port by using the `--port` flag or by indicating one in the `.env` file. The port defaults to `5000`.
+1. To deploy your mesh locally, use the `run` command. The port defaults to `5000`. You can specify a different port by using the `--port` flag or by adding your desired port number to the [`.env` file](#environment-variables), for example `PORT=9000`.
 
   ```terminal
-  aio api-mesh run --port 9000
+  aio api-mesh run mesh.json --port 9000
   ```
 
-  The console indicates your server status.
+  The console indicates your server status. If your build is successful, your mesh will be accessible at `http://localhost:5000/graphql` by default.
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -52,7 +52,7 @@ The `run` command is currently in beta.
 
 ## Environment variables
 
-Environment variables allow developers to make changes to a single variable, with one or more occurrences, across multiple meshes.
+Environment variables allow developers to make changes to a single variable, with one or more occurrences, across multiple meshes. An `.env` file will be created automatically when running the [`init` command](./command-reference.md#aio-api-meshinit).
 
 The [`create`](./command-reference.md#aio-api-meshcreate) and [`update`](./command-reference.md#aio-api-meshupdate) commands support the use of an `--env` flag, which allows you to provide an environment variables file location. For example:
 
@@ -70,6 +70,7 @@ The variables in your `.env` file are inserted into your mesh when the mesh is c
 APIName='Adobe Commerce API'
 commerceURL='<your_endpoint>'
 includeHTTPDetailsValue=true
+PORT=9000
 ```
 
 The following mesh uses the preceding `.env` file to populate the name and endpoint for the first source, as well as the state of the `includeHTTPDetails` flag.

--- a/src/pages/gateway/developer-tools.md
+++ b/src/pages/gateway/developer-tools.md
@@ -14,7 +14,7 @@ keywords:
 
 The processes covered in this topic allow developers to set up a local environment, use environment variables, and directly reference files in API Mesh for Adobe Developer App Builder.
 
-## Initiate a local environment
+## Create a local environment
 
 A local development environment for API Mesh allows you to run a local version for development and testing purposes.
 

--- a/src/pages/gateway/developer-tools.md
+++ b/src/pages/gateway/developer-tools.md
@@ -20,6 +20,10 @@ A local development environment for API Mesh allows you to run a local version f
 
 The [`aio api-mesh:init` command](./command-reference.md#aio-api-meshinit) allows you to build a local development environment at the specified location.
 
+<InlineAlert variant="info" slots="text"/>
+
+All of these steps can be automated using flags described in the [command reference](./command-reference.md#aio-api-meshinit).
+
 1. Run the following command.
 
     ```bash
@@ -44,7 +48,7 @@ The [`aio api-mesh:init` command](./command-reference.md#aio-api-meshinit) allow
 
 <InlineAlert variant="info" slots="text"/>
 
-All of these steps can be automated using flags described in the [command reference](./command-reference.md#aio-api-meshinit).
+The `run` command is currently in beta.
 
 ## Environment variables
 

--- a/src/pages/gateway/release-notes.md
+++ b/src/pages/gateway/release-notes.md
@@ -20,7 +20,7 @@ This release contains the following changes to API Mesh:
 
 ### Enhancements
 
-A [`run` command](./command-reference.md#aio-api-meshrun) beta is now available, which allows you to [create a local API Mesh environment](./developer-tools.md#create-a-local-environment) for development and testing purposes.
+A [`run` command](./command-reference.md#aio-api-meshrun) beta is now available, which allows you to [create a local API Mesh environment](./developer-tools.md#create-a-local-environment) for development and testing purposes. The `run` command works in concert with the [`init` command](./command-reference.md#aio-api-meshinit) and [environment variables](./developer-tools.md#environment-variables) to provide more robust developer tooling.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/gateway/release-notes.md
+++ b/src/pages/gateway/release-notes.md
@@ -20,7 +20,11 @@ This release contains the following changes to API Mesh:
 
 ### Enhancements
 
-A [`run` command](./command-reference.md#aio-api-meshrun) is now available, which allows you to [create a local API Mesh environment](./developer-tools.md#create-a-local-environment) for development and testing purposes.
+A [`run` command](./command-reference.md#aio-api-meshrun) beta is now available, which allows you to [create a local API Mesh environment](./developer-tools.md#create-a-local-environment) for development and testing purposes.
+
+<InlineAlert variant="info" slots="text"/>
+
+Beta features may not be fully supported.
 
 ## September 21, 2023
 

--- a/src/pages/gateway/release-notes.md
+++ b/src/pages/gateway/release-notes.md
@@ -14,6 +14,14 @@ keywords:
 
 The following sections indicate when updates were made to API Mesh for Adobe Developer App Builder. Refer to the [Upgrade version](upgrade.md) for more information on upgrading versions.
 
+## October 10, 2023
+
+This release contains the following changes to API Mesh:
+
+### Enhancements
+
+A [`run` command](./command-reference.md#aio-api-meshrun) is now available, which allows you to [create a local API Mesh environment](./developer-tools.md#create-a-local-environment) for development and testing purposes.
+
 ## September 21, 2023
 
 This release contains the following changes to API Mesh:
@@ -118,7 +126,7 @@ This release contains the following changes to API Mesh:
 
 Added several new tools for local development. We will continue to enhance developer tooling in future releases.
 
-- Added an [`init` command](./developer-tools.md#initiate-a-local-environment) to set up a local environment.
+- Added an [`init` command](./developer-tools.md#create-a-local-environment) to set up a local environment.
 - Enabled the use of a `.env` file to supply your mesh with [environment variables](./developer-tools.md#environment-variables).
 - Added the ability to [reference local files directly](./developer-tools.md#reference-files-directly) in your mesh, which removes the need to stringify and minify file attachments.
 

--- a/src/pages/gateway/release-notes.md
+++ b/src/pages/gateway/release-notes.md
@@ -14,7 +14,7 @@ keywords:
 
 The following sections indicate when updates were made to API Mesh for Adobe Developer App Builder. Refer to the [Upgrade version](upgrade.md) for more information on upgrading versions.
 
-## October 10, 2023
+## October 09, 2023
 
 This release contains the following changes to API Mesh:
 

--- a/src/pages/gateway/release-notes.md
+++ b/src/pages/gateway/release-notes.md
@@ -26,6 +26,8 @@ A [`run` command](./command-reference.md#aio-api-meshrun) beta is now available,
 
 Beta features may not be fully supported.
 
+To update to the newest version of the CLI, run `aio-update` or `aio plugins:update @adobe/aio-cli-plugin-api-mesh`.
+
 ## September 21, 2023
 
 This release contains the following changes to API Mesh:


### PR DESCRIPTION
This PR documents the `run command` for local development.

Pages affected:

- https://developer.adobe.com/graphql-mesh-gateway/gateway/command-reference/
- https://developer.adobe.com/graphql-mesh-gateway/gateway/developer-tools/