### PR TITLE
Add a linter to validate external links

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,6 +1,7 @@
-import remarkValidateLinks from 'remark-validate-links';
-import remarkFrontmatter from 'remark-frontmatter';
-import remarkLintFrontmatterSchema from 'remark-lint-frontmatter-schema';
+import remarkValidateLinks from "remark-validate-links";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkLintFrontmatterSchema from "remark-lint-frontmatter-schema";
+import remarkLintNoDeadUrls from "remark-lint-no-dead-urls";
 
 const remarkConfig = {
 	plugins: [
@@ -11,12 +12,20 @@ const remarkConfig = {
 			{
 				schemas: {
 					/* One schema for many files */
-					'./.github/linters/metadata.schema.yml': [
+					"./.github/linters/metadata.schema.yml": [
 						/* Support glob patterns ———v */
-						'./src/pages/**/*.md',
+						"./src/pages/**/*.md",
 					],
 				},
 			},
+		],
+		[
+			remarkLintNoDeadUrls,
+			{
+				skipUrlPatterns: [
+					"https://www.php.net"
+				]
+			}
 		],
 	],
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "remark-cli": "^10.0.1",
     "remark-frontmatter": "4.0.1",
     "remark-lint-frontmatter-schema": "^3.15.2",
+    "remark-lint-no-dead-urls": "^1.1.0",
     "remark-validate-links": "^11.0.2"
   },
   "scripts": {

--- a/src/pages/gateway/mesh_walkthrough.md
+++ b/src/pages/gateway/mesh_walkthrough.md
@@ -148,7 +148,7 @@ In your GraphQL client, run the following GraphQL queries:
 
 These queries demonstrate how you can return data from multiple sources within your mesh with a single request.
 
-The [`storeConfig`](https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/) query returns information from the `GraphQL` handler, while the [GetV1DirectoryCountries](https://adobe-commerce.redoc.ly/2.4.5-admin/tag/directorycountries#operation/GetV1DirectoryCountries) query returns information from the `REST`  handler.
+The [`storeConfig`](https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/) query returns information from the `GraphQL` handler, while the [GetV1DirectoryCountries](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/directorycountries#operation/GetV1DirectoryCountries) query returns information from the `REST`  handler.
 
 ## Add a transform
 

--- a/src/pages/gateway/overview.md
+++ b/src/pages/gateway/overview.md
@@ -65,7 +65,6 @@ If you encounter repeated `429` response codes or for any other security issues,
 [supports GraphQL queries]: https://devdocs.magento.com/guides/v2.4/graphql/index.html
 [GraphQL]: https://graphql.org/
 [GraphQL Mesh]: https://www.graphql-mesh.com/
-[mesh]: https://www.graphql-mesh.com/docs/getting-started/basic-usage
 [Getting started]: getting-started.md
 [Prerequisites]: getting-started.md#Prerequisites
 [Create an Adobe IO account]: getting-started.md#prerequisites

--- a/src/pages/reference/combining-multiple-sources.md
+++ b/src/pages/reference/combining-multiple-sources.md
@@ -333,9 +333,7 @@ The `additionalTypeDefs` configuration parameter allows you to merge GraphQL wit
 
 If we want to add the `Book.author` field, we first need to know what is the type of Author.
 
-Since the handlers generate most types, it might be hard to guess their correct spelling (e.g. `authors_v1_Author`). A quick way to build an `additionalTypeDefs` is to refer to the generated GraphQL Schema file of each Source that can be found in the [`.mesh/sources`](https://github.com/charlypoly/graphql-mesh-docs-first-gateway/tree/master/packages/multiple-sources/.mesh/sources/) directory.
-
-For example, the GraphQL Schema of the "Authors" Source can be found at [`.mesh/sources/Authors/schema.graphql`](https://github.com/charlypoly/graphql-mesh-docs-first-gateway/tree/master/packages/multiple-sources/.mesh/sources/Authors/schema.graphql):
+Since the handlers generate most types, it might be hard to guess their correct spelling (e.g. `authors_v1_Author`). A quick way to build an `additionalTypeDefs` is to refer to the generated GraphQL Schema file of each Source.
 
 ```graphql
 schema {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2798,6 +2798,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@leichtgewicht/ip-codec@npm:^2.0.1":
+  version: 2.0.4
+  resolution: "@leichtgewicht/ip-codec@npm:2.0.4"
+  checksum: 468de1f04d33de6d300892683d7c8aecbf96d1e2c5fe084f95f816e50a054d45b7c1ebfb141a1447d844b86a948733f6eebd92234da8581c84a1ad4de2946a2d
+  languageName: node
+  linkType: hard
+
 "@lezer/common@npm:^0.15.0, @lezer/common@npm:^0.15.7":
   version: 0.15.12
   resolution: "@lezer/common@npm:0.15.12"
@@ -6406,6 +6413,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"check-links@npm:^1.1.8":
+  version: 1.1.8
+  resolution: "check-links@npm:1.1.8"
+  dependencies:
+    got: ^9.6.0
+    is-relative-url: ^2.0.0
+    p-map: ^2.0.0
+    p-memoize: ^2.1.0
+  checksum: b73296feb4f4a6b58fd93fb34a8252e42dae166b3232e789dad02e378dddd3d46427906291beb033b6bc273b4c0ffc0e51a7e9762b6a52e70eaa719ade164310
+  languageName: node
+  linkType: hard
+
 "cheerio-select@npm:^2.1.0":
   version: 2.1.0
   resolution: "cheerio-select@npm:2.1.0"
@@ -6624,6 +6643,13 @@ __metadata:
   version: 1.2.1
   resolution: "clsx@npm:1.2.1"
   checksum: 30befca8019b2eb7dbad38cff6266cf543091dae2825c856a62a8ccf2c3ab9c2907c4d12b288b73101196767f66812365400a227581484a05f968b0307cfaf12
+  languageName: node
+  linkType: hard
+
+"co@npm:3.1.0":
+  version: 3.1.0
+  resolution: "co@npm:3.1.0"
+  checksum: b7c685595103663317be1cbe3a00386b0b3643a6a859aaeb20ca2a7fa8b0d5c5f744de55d8b0b44bb07635c86bcd48d64684fcfccf52381ede3de55ed374dc80
   languageName: node
   linkType: hard
 
@@ -7801,6 +7827,24 @@ __metadata:
   dependencies:
     path-type: ^4.0.0
   checksum: fa05e18324510d7283f55862f3161c6759a3f2f8dbce491a2fc14c8324c498286c54282c1f0e933cb930da8419b30679389499b919122952a4f8592362ef4615
+  languageName: node
+  linkType: hard
+
+"dns-packet@npm:^5.2.4":
+  version: 5.6.1
+  resolution: "dns-packet@npm:5.6.1"
+  dependencies:
+    "@leichtgewicht/ip-codec": ^2.0.1
+  checksum: 64c06457f0c6e143f7a0946e0aeb8de1c5f752217cfa143ef527467c00a6d78db1835cfdb6bb68333d9f9a4963cf23f410439b5262a8935cce1236f45e344b81
+  languageName: node
+  linkType: hard
+
+"dns-socket@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "dns-socket@npm:4.2.2"
+  dependencies:
+    dns-packet: ^5.2.4
+  checksum: d02b83ecc9b0f1d2fc459f93c6390c768a8805002637d1f74113d623fa7b2478a695ade7761a0a847622781f5e6dd008a9a1469ac75a617bdf1b775f2156943c
   languageName: node
   linkType: hard
 
@@ -10785,6 +10829,7 @@ __metadata:
     remark-cli: ^10.0.1
     remark-frontmatter: 4.0.1
     remark-lint-frontmatter-schema: ^3.15.2
+    remark-lint-no-dead-urls: ^1.1.0
     remark-validate-links: ^11.0.2
   languageName: unknown
   linkType: soft
@@ -11652,6 +11697,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ip-regex@npm:^4.0.0":
+  version: 4.3.0
+  resolution: "ip-regex@npm:4.3.0"
+  checksum: 7ff904b891221b1847f3fdf3dbb3e6a8660dc39bc283f79eb7ed88f5338e1a3d1104b779bc83759159be266249c59c2160e779ee39446d79d4ed0890dfd06f08
+  languageName: node
+  linkType: hard
+
 "ip@npm:^2.0.0":
   version: 2.0.0
   resolution: "ip@npm:2.0.0"
@@ -11663,6 +11715,13 @@ __metadata:
   version: 1.9.1
   resolution: "ipaddr.js@npm:1.9.1"
   checksum: f88d3825981486f5a1942414c8d77dd6674dd71c065adcfa46f578d677edcb99fda25af42675cb59db492fdf427b34a5abfcde3982da11a8fd83a500b41cfe77
+  languageName: node
+  linkType: hard
+
+"is-absolute-url@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "is-absolute-url@npm:2.1.0"
+  checksum: 781e8cf8a2af54b1b7a92f269244d96c66224030d91120e734ebeebbce044c167767e1389789d8aaf82f9e429cb20ae93d6d0acfe6c4b53d2bd6ebb47a236d76
   languageName: node
   linkType: hard
 
@@ -11931,6 +11990,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-ip@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "is-ip@npm:3.1.0"
+  dependencies:
+    ip-regex: ^4.0.0
+  checksum: da2c2b282407194adf2320bade0bad94be9c9d0bdab85ff45b1b62d8185f31c65dff3884519d57bf270277e5ea2046c7916a6e5a6db22fe4b7ddcdd3760f23eb
+  languageName: node
+  linkType: hard
+
 "is-lambda@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
@@ -12000,6 +12068,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-online@npm:^8.2.1":
+  version: 8.5.1
+  resolution: "is-online@npm:8.5.1"
+  dependencies:
+    got: ^9.6.0
+    p-any: ^2.0.0
+    p-timeout: ^3.0.0
+    public-ip: ^4.0.1
+  checksum: 87d7f321dc872f0e4c7ac058595dcd058d7e09931f3b4fc29164f9d610564b9e9b15adf9ff4427bd273a47ef0da55b66a97a0e535584249d04a26d0ec134bf56
+  languageName: node
+  linkType: hard
+
 "is-path-inside@npm:^3.0.2":
   version: 3.0.3
   resolution: "is-path-inside@npm:3.0.3"
@@ -12058,6 +12138,15 @@ __metadata:
     call-bind: ^1.0.2
     has-tostringtag: ^1.0.0
   checksum: 362399b33535bc8f386d96c45c9feb04cf7f8b41c182f54174c1a45c9abbbe5e31290bbad09a458583ff6bf3b2048672cdb1881b13289569a7c548370856a652
+  languageName: node
+  linkType: hard
+
+"is-relative-url@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-relative-url@npm:2.0.0"
+  dependencies:
+    is-absolute-url: ^2.0.0
+  checksum: 5acb66d6374a0c89fb68a770c94eeee3061b7d2e94d1fdff4d780b3054caf681ad33ed9d554eebeaedd897d90b781684c84ed85c7581d5d50767e857af3a199e
   languageName: node
   linkType: hard
 
@@ -13342,7 +13431,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"map-age-cleaner@npm:^0.1.3":
+"map-age-cleaner@npm:^0.1.1, map-age-cleaner@npm:^0.1.3":
   version: 0.1.3
   resolution: "map-age-cleaner@npm:0.1.3"
   dependencies:
@@ -13766,6 +13855,17 @@ __metadata:
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
   checksum: af1b38516c28ec95d6b0826f6c8f276c58aec391f76be42aa07646b4e39d317723e869700933ca6995b056db4b09a78c92d5440dc23657e6764be5d28874bba1
+  languageName: node
+  linkType: hard
+
+"mem@npm:^4.0.0":
+  version: 4.3.0
+  resolution: "mem@npm:4.3.0"
+  dependencies:
+    map-age-cleaner: ^0.1.1
+    mimic-fn: ^2.0.0
+    p-is-promise: ^2.0.0
+  checksum: cf488608e5d59c6cb68004b70de317222d4be9f857fd535dfa6a108e04f40821479c080bc763c417b1030569d303538c59d441280078cfce07fefd1c523f98ef
   languageName: node
   linkType: hard
 
@@ -14222,7 +14322,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-fn@npm:^2.1.0":
+"mimic-fn@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "mimic-fn@npm:1.2.0"
+  checksum: 69c08205156a1f4906d9c46f9b4dc08d18a50176352e77fdeb645cedfe9f20c0b19865d465bd2dec27a5c432347f24dc07fc3695e11159d193f892834233e939
+  languageName: node
+  linkType: hard
+
+"mimic-fn@npm:^2.0.0, mimic-fn@npm:^2.1.0":
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
@@ -15292,6 +15399,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-any@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "p-any@npm:2.1.0"
+  dependencies:
+    p-cancelable: ^2.0.0
+    p-some: ^4.0.0
+    type-fest: ^0.3.0
+  checksum: c65924474214b5cb66b4ad8a2860f4d57f1cde81c0e0f505c013ee7bc9bde1ea68d0a6a82732f16643f8e14d473887da5d617397ccda4bf25a218492d70a1d86
+  languageName: node
+  linkType: hard
+
 "p-cancelable@npm:^1.0.0":
   version: 1.1.0
   resolution: "p-cancelable@npm:1.1.0"
@@ -15324,6 +15442,13 @@ __metadata:
   version: 1.0.0
   resolution: "p-finally@npm:1.0.0"
   checksum: 93a654c53dc805dd5b5891bab16eb0ea46db8f66c4bfd99336ae929323b1af2b70a8b0654f8f1eae924b2b73d037031366d645f1fd18b3d30cbd15950cc4b1d4
+  languageName: node
+  linkType: hard
+
+"p-is-promise@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "p-is-promise@npm:2.1.0"
+  checksum: c9a8248c8b5e306475a5d55ce7808dbce4d4da2e3d69526e4991a391a7809bfd6cfdadd9bf04f1c96a3db366c93d9a0f5ee81d949e7b1684c4e0f61f747199ef
   languageName: node
   linkType: hard
 
@@ -15390,12 +15515,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-map@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "p-map@npm:2.1.0"
+  checksum: 9e3ad3c9f6d75a5b5661bcad78c91f3a63849189737cd75e4f1225bf9ac205194e5c44aac2ef6f09562b1facdb9bd1425584d7ac375bfaa17b3f1a142dab936d
+  languageName: node
+  linkType: hard
+
 "p-map@npm:^4.0.0":
   version: 4.0.0
   resolution: "p-map@npm:4.0.0"
   dependencies:
     aggregate-error: ^3.0.0
   checksum: cb0ab21ec0f32ddffd31dfc250e3afa61e103ef43d957cc45497afe37513634589316de4eb88abdfd969fe6410c22c0b93ab24328833b8eb1ccc087fc0442a1c
+  languageName: node
+  linkType: hard
+
+"p-memoize@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "p-memoize@npm:2.1.0"
+  dependencies:
+    mem: ^4.0.0
+    mimic-fn: ^1.0.0
+  checksum: dea93ed68cfc9be8d147054c5ccd70c8145224de828ad84246273ac41b601e6f6becadae7c3be8e93ffc6673767e79c781706f88b3f67d74ba95ef631d3b033e
   languageName: node
   linkType: hard
 
@@ -15409,7 +15551,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-timeout@npm:^3.2.0":
+"p-some@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "p-some@npm:4.1.0"
+  dependencies:
+    aggregate-error: ^3.0.0
+    p-cancelable: ^2.0.0
+  checksum: 7ef6a808c53ac2d96954dd26c1406ebbc14c89a092f46f65b0902601ed9db3b2fb7855d18624645157d56de9a51c59ce98378a68b797617204028addfbada10a
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^3.0.0, p-timeout@npm:^3.2.0":
   version: 3.2.0
   resolution: "p-timeout@npm:3.2.0"
   dependencies:
@@ -16645,6 +16797,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"public-ip@npm:^4.0.1":
+  version: 4.0.4
+  resolution: "public-ip@npm:4.0.4"
+  dependencies:
+    dns-socket: ^4.2.2
+    got: ^9.6.0
+    is-ip: ^3.1.0
+  checksum: 9a0c3194b219d14e8996080f90857ca025c37ebe233cb89b7ba629714ebcdc6dfd563084931d497c597b56599468ec064b7a9196bbdc92feefa908d1e1585ea7
+  languageName: node
+  linkType: hard
+
 "pump@npm:^3.0.0":
   version: 3.0.0
   resolution: "pump@npm:3.0.0"
@@ -17358,6 +17521,18 @@ __metadata:
     unified-lint-rule: ^2.1.1
     yaml: ^2.2.1
   checksum: f0b027cc83eb27046f06e7e13b42837864f56688d24e4c4464b1bcab159a881824f94787d28f43b06d88a6f3075db4294bf4aebe329d95c94f4516b934ca6442
+  languageName: node
+  linkType: hard
+
+"remark-lint-no-dead-urls@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "remark-lint-no-dead-urls@npm:1.1.0"
+  dependencies:
+    check-links: ^1.1.8
+    is-online: ^8.2.1
+    unified-lint-rule: ^1.0.4
+    unist-util-visit: ^2.0.1
+  checksum: e409b9896b6da801643b07514a32b7ff55b0f056f4585a6fdfaad7900e41907368750bccd84ae24d7f633291457243e01f871cd9a74f04befce37b6d8c0f165a
   languageName: node
   linkType: hard
 
@@ -18405,6 +18580,13 @@ __metadata:
     astral-regex: ^2.0.0
     is-fullwidth-code-point: ^3.0.0
   checksum: 4a82d7f085b0e1b070e004941ada3c40d3818563ac44766cca4ceadd2080427d337554f9f99a13aaeb3b4a94d9964d9466c807b3d7b7541d1ec37ee32d308756
+  languageName: node
+  linkType: hard
+
+"sliced@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "sliced@npm:1.0.1"
+  checksum: 84528d23279985ead75809eeec5d601b0fb6bc28348c6627f4feb40747533a1e36a75e8bc60f9079528079b21c434890b397e8fc5c24a649165cc0bbe90b4d70
   languageName: node
   linkType: hard
 
@@ -19680,6 +19862,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "type-fest@npm:0.3.1"
+  checksum: 347ff46c2285616635cb59f722e7f396bee81b8988b6fc1f1536b725077f2abf6ccfa22ab7a78e9b6ce7debea0e6614bbf5946cbec6674ec1bde12113af3a65c
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^0.8.0, type-fest@npm:^0.8.1":
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
@@ -19876,6 +20065,15 @@ __metadata:
     vfile-reporter: ^7.0.0
     vfile-statistics: ^2.0.0
   checksum: 95020f67ff31c7f95d7d7d7f81121ea1d2dac5ba547b5405b9a35d8f9e45bf92fd343dce54a754ad85aaace11269c7fc076056309732697a7f86e7a9542ab3ec
+  languageName: node
+  linkType: hard
+
+"unified-lint-rule@npm:^1.0.4":
+  version: 1.0.6
+  resolution: "unified-lint-rule@npm:1.0.6"
+  dependencies:
+    wrapped: ^1.0.1
+  checksum: fb3fa8a08bab260e8200a40de48180d422cc7beb118cd74352490a6e8e42346ffbaed47e43593df4b5519eead0f67d71d1e4031b1b100a9aaf5f42d7b6135d54
   languageName: node
   linkType: hard
 
@@ -20196,7 +20394,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unist-util-visit@npm:2.0.3, unist-util-visit@npm:^2.0.0, unist-util-visit@npm:^2.0.3":
+"unist-util-visit@npm:2.0.3, unist-util-visit@npm:^2.0.0, unist-util-visit@npm:^2.0.1, unist-util-visit@npm:^2.0.3":
   version: 2.0.3
   resolution: "unist-util-visit@npm:2.0.3"
   dependencies:
@@ -21041,6 +21239,16 @@ __metadata:
     string-width: ^4.1.0
     strip-ansi: ^6.0.0
   checksum: a790b846fd4505de962ba728a21aaeda189b8ee1c7568ca5e817d85930e06ef8d1689d49dbf0e881e8ef84436af3a88bc49115c2e2788d841ff1b8b5b51a608b
+  languageName: node
+  linkType: hard
+
+"wrapped@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "wrapped@npm:1.0.1"
+  dependencies:
+    co: 3.1.0
+    sliced: ^1.0.1
+  checksum: 549d3a0dae46f97eae15f749dc9c512cbbb0db716e1f2bc48e3e134123c941750ed008bb2799d154406154e69fb3b2e504964d9bd8e3c63e99ac4991cfd00ae8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR):
- Adds a plugin [remark-lint-no-dead-urls](https://github.com/remarkjs/remark-lint-no-dead-urls) to ensure that external URLs in Markdown pages are working. The linter returns warnings on https://www.php.net/ on working links in some reason (I assume server related issues) so I excluded this domain in the configuration.
- Replaces or removes dead links

Internal ticket: COMDOX-156

## Test

[Failed validate job](https://github.com/AdobeDocs/commerce-testing/actions/runs/6948160793/job/18903522012#step:11:12) reporting about dead links.
