### PR TITLE
Downgrade theme to v4.11.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AdobeDocs/graphql-mesh-gateway"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "^4.11.10",
+    "@adobe/gatsby-theme-aio": "4.11.9",
     "gatsby": "4.22.0",
     "gatsby-plugin-html-comments": "^1.0.0",
     "react": "^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,9 +33,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:^4.11.10":
-  version: 4.11.10
-  resolution: "@adobe/gatsby-theme-aio@npm:4.11.10"
+"@adobe/gatsby-theme-aio@npm:4.11.9":
+  version: 4.11.9
+  resolution: "@adobe/gatsby-theme-aio@npm:4.11.9"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
@@ -131,7 +131,7 @@ __metadata:
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: a18fc9b2ee86fdbb8f7f1d92f25f8190f3eb307581d32bd865d7ffa7d77c2bc60db23ff5a1e740238678332d7a4ecbffaeab606a2ab5502162223e02ca95eb3f
+  checksum: 57693d220f785d6ffa8c81c09fce1b15240de6ce483df835b5b5b373124e1b1349c99f170b2694c25b2271aff84b16eef8e5975c1f7b33f24a297a3b03e8e871
   languageName: node
   linkType: hard
 
@@ -11012,7 +11012,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "graphql-mesh-gateway@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": ^4.11.10
+    "@adobe/gatsby-theme-aio": 4.11.9
     gatsby: 4.22.0
     gatsby-plugin-html-comments: ^1.0.0
     react: ^17.0.0


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) downgrades the theme to latest official version v4.11.9.

Jira: COMDOX-913

## Preview

https://developer-stage.adobe.com/graphql-mesh-gateway/