### PR TITLE
Clarify mesh initialization

### DIFF
--- a/src/pages/mesh/basic/create-mesh.md
+++ b/src/pages/mesh/basic/create-mesh.md
@@ -119,7 +119,7 @@ Legacy mesh URLs will be removed in the future. Use the edge mesh URLs whenever 
 
 ## Optimizing edge mesh performance
 
-Edge meshes are resilient and performant because they exist closer to the origin of your query, in over 330 locations in 120 countries. This means that your queries can hit a server that has not cached your mesh, causing a cold start.
+Edge meshes are resilient and performant because they exist closer to the origin of your query, in over 330 locations in 120 countries. This means that your queries can hit a server that has not initialized your mesh, causing a cold start.
 
 If you are using an API platform or a GraphQL client, add the [`Connection: Keep-Alive`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive) header to your requests. This header keeps the connection to the server open for future requests, which can significantly improve performance because it ensures you are hitting a warm cache. Using this header also prevents the unnecessary repetition of several steps of the [HTTP handshake](https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x).
 


### PR DESCRIPTION
This PR updates wording to clarify that the mesh initializing is what causes a cold start.