### PR TITLE
Update Fastly/API Mesh documentation

### DIFF
--- a/src/pages/mesh/advanced/caching/fastly.md
+++ b/src/pages/mesh/advanced/caching/fastly.md
@@ -19,7 +19,7 @@ Adding a content delivery network (CDN) for caching dynamic content with API Mes
 
 <InlineAlert variant="info" slots="text"/>
 
-After adding VCL snippets in the [Fastly Setup](#configure-fastly-in-adobe-commerce), your Commerce GraphQL URL is now in the following format : `<Commerce-URL>/api/<meshId>/graphql`
+After adding VCL snippets in the [Fastly Setup](#configure-fastly-in-adobe-commerce), your Commerce GraphQL URL is now in the following format: `<Commerce-URL>/api/<meshId>/graphql`
 
 To distinguish between requests from users and requests from API Mesh, use the following source operation header to prevent Fastly from caching headers that come directly from API Mesh:
 
@@ -108,6 +108,8 @@ API Mesh prefixes any Fastly source headers with their source name. For example,
 After you [create](../../basic/create-mesh.md#create-a-mesh) or [update](../../basic/create-mesh.md#update-an-existing-mesh) your mesh, run an [`aio api-mesh:describe`](../../advanced/index.md#aio-api-meshdescribe) command to view your mesh URL. Run a query against this URL to confirm that your mesh is working correctly.
 
 ## Configure Fastly in Adobe Commerce
+
+The following sections describe how to configure Fastly in Adobe Commerce.
 
 ### Add VCL snippets
 
@@ -226,11 +228,11 @@ In **Fastly Configuration** click **Upload VCL to Fastly**. Click **Save Config*
 
 ### Configure default backend
 
-The default backend must not handle the "/api/" requests. To achieve, we are adding a condition to the existing backend.
+The default backend does not handle "/api/" requests. To allow API requests, add a condition to the existing backend:
 
-- In **Fastly Configuration > Backend Settings**, click on the wheel of the backend named **<project_id>.magento.cloud**.
+1. In **Fastly Configuration > Backend Settings**, click on the gear icon next to **<project_id>.magento.cloud**.
 
-- Here, click on "Create a new request condition" like :
+1. Click **Create a new request condition** and add a condition like the following example:
 
      - **Name** - default_backend
      - **Apply if...**:
@@ -239,8 +241,8 @@ The default backend must not handle the "/api/" requests. To achieve, we are add
         req.url !~ "^/api/"
         ```
 
-- Click on "Create" of the condition
-- Click on "Create" of the backend
+1. Click **Create** on the condition.
+1. Click **Create** on the backend.
 
 ## Test your configuration
 

--- a/src/pages/mesh/advanced/caching/fastly.md
+++ b/src/pages/mesh/advanced/caching/fastly.md
@@ -15,7 +15,6 @@ keywords:
 
 Adding a content delivery network (CDN) for caching dynamic content with API Mesh for Adobe Developer App Builder provides additional security and improved performance. Follow these instructions to integrate API Mesh, Adobe Commerce, and [Fastly](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/cdn/fastly.html?lang=en) (provided with Adobe Commerce Pro accounts).
 
-
 ## Configure headers in API Mesh
 
 <InlineAlert variant="info" slots="text"/>
@@ -133,7 +132,6 @@ After setting up your API Mesh, open your Adobe Commerce Admin and use the follo
   **NOTE**: The `Priority` of each VCL snippet determines the order in which VCL subroutines are executed. The following `Priority` fields only apply to the default configuration of Adobe Commerce. If you have other custom snippets, you will need to adjust the priorities accordingly.
 
    - Allows API Mesh to function as a [Fastly backend](https://developer.fastly.com/reference/vcl/declarations/backend/).
-     
      - **Name** - api_mesh_backend
      - **Type** - **init**
      - **Priority** - **1**
@@ -170,7 +168,6 @@ After setting up your API Mesh, open your Adobe Commerce Admin and use the follo
         ```
 
    - Enables the bypass header in API Mesh:
-     
      - **Name** - api_mesh_recv
      - **Type** - **recv**
      - **Priority** - **10**
@@ -183,7 +180,6 @@ After setting up your API Mesh, open your Adobe Commerce Admin and use the follo
         ```
 
    - Determines what GraphQL can be cached:
-     
      - **Name** - api_mesh_recv_graphql
      - **Type** - **recv**
      - **Priority** - **60**
@@ -203,7 +199,6 @@ After setting up your API Mesh, open your Adobe Commerce Admin and use the follo
         ```
 
    - Cache miss:
-
      - **Name** - api_mesh_miss
      - **Type** - **miss**
      - **Priority** - **60**
@@ -251,9 +246,7 @@ After setting up your API Mesh, open your Adobe Commerce Admin and use the follo
         }
         ```
 
-
 In **Fastly Configuration** click **Upload VCL to Fastly**. Click **Save Config**.
-
 
 ## Test your configuration
 

--- a/src/pages/mesh/advanced/caching/fastly.md
+++ b/src/pages/mesh/advanced/caching/fastly.md
@@ -238,6 +238,7 @@ The default backend must not handle the "/api/" requests. To achieve, we are add
         ```csharp
         req.url !~ "^/api/"
         ```
+
 - Click on "Create" of the condition
 - Click on "Create" of the backend
 

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -44,7 +44,7 @@ If you have an allowlist, add the [edge mesh IP addresses](https://www.cloudflar
 
 <InlineAlert variant="info" slots="text"/>
 
-If you intend to use Fastly, follow [Configure Fastly for edge meshes](../advanced/caching/fastly.md#configure-fastly-for-edge-meshes).
+If you intend to use Fastly, follow [Configure Fastly for edge meshes](../advanced/caching/fastly.md).
 
 The following commands will take slightly longer to complete. Consider using [local development](../advanced/developer-tools.md#local-development-files) for testing and development purposes:
 

--- a/src/pages/mesh/release/update.md
+++ b/src/pages/mesh/release/update.md
@@ -39,7 +39,7 @@ Edge meshes can take slightly longer to build than legacy meshes. Wait two or th
 
 ## Fastly and edge meshes
 
-If you intend to use Fastly, follow [Configure Fastly for edge meshes](../advanced/caching/fastly.md#configure-fastly-for-edge-meshes).
+If you intend to use Fastly, follow [Configure Fastly for edge meshes](../advanced/caching/fastly.md).
 
 ## Key Dates
 


### PR DESCRIPTION
## Purpose of this pull request

- Remove some outdated information
- Let only 1 way to add api mesh backend
- Add the TLS 1.3 lines mandatory for edge mesh)

## Affected pages

https://developer.adobe.com/graphql-mesh-gateway/mesh/advanced/caching/fastly/
https://developer.adobe.com/graphql-mesh-gateway/mesh/release/
https://developer.adobe.com/graphql-mesh-gateway/mesh/release/update