### PR TITLE
fixing `keep-alive` capitalization

### DIFF
--- a/src/pages/mesh/advanced/secrets.md
+++ b/src/pages/mesh/advanced/secrets.md
@@ -213,7 +213,7 @@ Use the following GraphQL query to retrieve the headers. This query will vary de
         "cf-ipcountry": "US",
         "cf-ray": "abc123abc123",
         "cf-visitor": "{\"scheme\":\"https\"}",
-        "connection": "Keep-Alive",
+        "connection": "keep-alive",
         "host": "header-reflection-service",
         "secretaemeader": "abcabcdefdefxyzxyz",
         "secretheader": "\\/root",

--- a/src/pages/mesh/basic/create-mesh.md
+++ b/src/pages/mesh/basic/create-mesh.md
@@ -121,11 +121,11 @@ Legacy mesh URLs will be removed in the future. Use the edge mesh URLs whenever 
 
 Edge meshes are resilient and performant because they exist closer to the origin of your query, in over 330 locations in 120 countries. This means that your queries can hit a server that has not initialized your mesh, causing a cold start.
 
-If you are using an API platform or a GraphQL client, add the [`Connection: Keep-Alive`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive) header to your requests. This header keeps the connection to the server open for future requests, which can significantly improve performance because it ensures you are hitting a warm cache. Using this header also prevents the unnecessary repetition of several steps of the [HTTP handshake](https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x).
+If you are using an API platform or a GraphQL client, add the [`Connection: keep-alive`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive) header to your requests. This header keeps the connection to the server open for future requests, which can significantly improve performance because it ensures you are hitting a warm cache. Using this header also prevents the unnecessary repetition of several steps of the [HTTP handshake](https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x).
 
 <InlineAlert variant="info" slots="text"/>
 
-Some platforms and command-line tools, such as cURL, do not respect the `Connection: Keep-Alive` header. Consider [priming your mesh](../best-practices/performance.md) to improve performance.
+Some platforms and command-line tools, such as cURL, do not respect the `Connection: keep-alive` header. Consider [priming your mesh](../best-practices/performance.md) to improve performance.
 
 ## Create a mesh from a source
 

--- a/src/pages/mesh/best-practices/performance.md
+++ b/src/pages/mesh/best-practices/performance.md
@@ -14,15 +14,15 @@ keywords:
 
 When performance testing edge meshes on API Mesh for Adobe Developer App Builder, you need to account for cold starts to get an accurate measurement of the performance.
 
-If applicable, you should use the `Connection: Keep-Alive` header described in [Optimizing edge mesh performance](../basic/create-mesh.md#optimizing-edge-mesh-performance).
+If applicable, you should use the `Connection: keep-alive` header described in [Optimizing edge mesh performance](../basic/create-mesh.md#optimizing-edge-mesh-performance).
 
-Additionally, you can prime your mesh by making several repeated calls to the mesh that do not make calls to your sources. This is also useful for increasing performance using cURL or other tools that do not support the `Keep-Alive` header.
+Additionally, you can prime your mesh by making several repeated calls to the mesh that do not make calls to your sources. This is also useful for increasing performance using cURL or other tools that do not support the `keep-alive` header.
 
 <InlineAlert variant="info" slots="text"/>
 
-If you are using the `Connection: Keep-Alive` header, you only need to prime with one or two calls before testing.
+If you are using the `Connection: keep-alive` header, you only need to prime with one or two calls before testing.
 
-If you are not using the `Keep-Alive` header, you can prime your mesh by repeating the following query 100-200 times before performance testing:
+If you are not using the `keep-alive` header, you can prime your mesh by repeating the following query 100-200 times before performance testing:
 
 ```graphql
 {

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -64,7 +64,7 @@ With the update to edge, API Mesh no longer requires API keys.
 
 When performance testing edge meshes in API Mesh, you need to account for cold starts to get an accurate measurement of the performance.
 
-If applicable, you should use the `Connection: Keep-Alive` header described in [Optimizing edge mesh performance](../basic/create-mesh.md#optimizing-edge-mesh-performance).
+If applicable, you should use the `Connection: keep-alive` header described in [Optimizing edge mesh performance](../basic/create-mesh.md#optimizing-edge-mesh-performance).
 
 Alternatively, you can manually warm the cache using the process described in [Performance testing](../best-practices/performance.md#performance-testing).
 

--- a/src/pages/mesh/release/update.md
+++ b/src/pages/mesh/release/update.md
@@ -52,6 +52,6 @@ If you have any questions or concerns, contact our team directly, by emailing nr
 
 When performance testing edge meshes in API Mesh, you need to account for cold starts to get an accurate measurement of the performance.
 
-If applicable, you should use the `Connection: Keep-Alive` header described in [Optimizing edge mesh performance](../basic/create-mesh.md#optimizing-edge-mesh-performance).
+If applicable, you should use the `Connection: keep-alive` header described in [Optimizing edge mesh performance](../basic/create-mesh.md#optimizing-edge-mesh-performance).
 
 Alternatively, you can manually warm the cache using the process described in [Performance testing](../best-practices/performance.md#performance-testing).


### PR DESCRIPTION
This PR fixes capitalization in the `keep-alive` header as some browsers are sensitive to it.