### PR TITLE
Removing workspace requirement

### DIFF
--- a/src/pages/mesh/best-practices/performance.md
+++ b/src/pages/mesh/best-practices/performance.md
@@ -14,7 +14,7 @@ keywords:
 
 When performance testing edge meshes on API Mesh for Adobe Developer App Builder, you need to account for cold starts to get an accurate measurement of the performance.
 
-For performance testing, your edge mesh must be in a ["Production" workspace](../basic/work-with-mesh.md#projects-and-workspaces) on the Adobe Developer console. If your mesh existed before the September 23, 2024 release, you must run the `aio api-mesh update` command on your Production edge mesh before you can benefit from this enhancement.
+If your mesh existed before the September 23, 2024 release, you must run the `aio api-mesh update` command on your edge mesh before you can benefit from this enhancement.
 
 If applicable, you should use the `Connection: keep-alive` header described in [Optimizing edge mesh performance](../basic/create-mesh.md#optimizing-edge-mesh-performance).
 

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -18,13 +18,13 @@ import UpdateNotice from '/src/_includes/update-notice.md'
 
 The following sections list updates to API Mesh for Adobe Developer App Builder. Refer to the [Upgrade version](upgrade.md) for more information on upgrading.
 
-## September 23, 2024
+## September 24, 2024
 
 This release contains the following changes to API Mesh:
 
 ### Enhancements
 
-Improved performance during cold starts for edge meshes. To benefit from this enhancement, your edge mesh must be in a ["Production" workspace](../basic/work-with-mesh.md#projects-and-workspaces) on the Adobe Developer console. For previously created meshes, you must run the `aio api-mesh update` command on your Production edge mesh before you can benefit from this enhancement.
+Improved performance during cold starts for edge meshes. For previously created meshes, you must run the `aio api-mesh update` command on your edge mesh before you can benefit from this enhancement.
 
 ## August 15, 2024
 


### PR DESCRIPTION
This PR updates previous restrictions for performance testing. As long as the mesh is updated after today's deployment, all edge meshes will benefit from the performance enhancements, regardless of workspace name. 