### PR TITLE
November update

### DIFF
--- a/src/pages/mesh/advanced/hooks.md
+++ b/src/pages/mesh/advanced/hooks.md
@@ -16,10 +16,6 @@ keywords:
 
 The hooks feature is currently in development and will be expanded in future releases. Only `beforeAll` hooks are currently available.
 
-<InlineAlert variant="warning" slots="text"/>
-
-Edge meshes do not currently support local hooks. If you are using local hooks, you must use a legacy mesh. Remote hooks continue to function as expected. Local hooks will be available in edge meshes in the future.
-
 Hooks allow you to invoke a composable [local or remote](#local-vs-remote-functions) function on a targeted node.
 
 Some use cases for the `Hooks` include:

--- a/src/pages/mesh/basic/create-mesh.md
+++ b/src/pages/mesh/basic/create-mesh.md
@@ -111,7 +111,7 @@ The edge mesh URL offers several benefits because the edge is closer to your dat
 
 <InlineAlert variant="warning" slots="text"/>
 
-Edge meshes do not currently support Hooks or SOAP handlers. If you need to use these features, you must use a legacy mesh. These features will be available in edge meshes in the future.
+Edge meshes do not currently support SOAP handlers. If you need to use these features, you must use a legacy mesh. These features will be available in edge meshes in the future.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/mesh/basic/create-mesh.md
+++ b/src/pages/mesh/basic/create-mesh.md
@@ -111,7 +111,7 @@ The edge mesh URL offers several benefits because the edge is closer to your dat
 
 <InlineAlert variant="warning" slots="text"/>
 
-Edge meshes do not currently support SOAP handlers. If you need to use these features, you must use a legacy mesh. These features will be available in edge meshes in the future.
+Edge meshes do not currently support SOAP handlers. If you need to use this feature, you must use a legacy mesh. SOAP handler support will be available in edge meshes in the future.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/mesh/basic/create-mesh.md
+++ b/src/pages/mesh/basic/create-mesh.md
@@ -111,7 +111,7 @@ The edge mesh URL offers several benefits because the edge is closer to your dat
 
 <InlineAlert variant="warning" slots="text"/>
 
-Edge meshes do not currently support SOAP handlers. If you need to use this feature, you must use a legacy mesh. SOAP handler support will be available in edge meshes in the future.
+Edge meshes do not support SOAP handlers.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/mesh/basic/handlers/graphql.md
+++ b/src/pages/mesh/basic/handlers/graphql.md
@@ -86,7 +86,25 @@ Header names are automatically converted to lowercase.
 
 ## Provide an introspection file
 
-If introspection is disabled in the production environment of your GraphQL source, and you want to provide your schema definition or introspection separately, you can use the `source` field to provide an introspection file:
+If introspection is disabled in the production environment of your GraphQL source, and you want to provide your schema definition or introspection separately, you can use the `source` field to provide an online or local introspection file:
+
+```json
+{
+  "meshConfig": {
+    "sources": [
+      {
+        "name": "test_automation",
+        "handler": {
+          "graphql": {
+            "endpoint": "https://venia.magento.com/graphql",
+            "source": "https://<domain>/myFile.graphql"
+          }
+        }
+      }
+    ]
+  }
+}
+```
 
 ```json
 {
@@ -97,60 +115,24 @@ If introspection is disabled in the production environment of your GraphQL sourc
         "handler": {
           "graphql": {
             "endpoint": "https://venia.magento.com/graphql",
-            "source": "./schema.graphql"
+            "source": "schema.graphql"
           }
         }
       }
+    ],
+    "files": [
+      {
+        "path": "schema.graphql",
+        "content": "type Query {hello: String}"
+      }
     ]
-  },
+  }
 }
 ```
 
 ## Local Schemas
 
 We recommend providing a local schema by using the [`additionalTypeDefs`](../../advanced/extend/index.md) and [`additionalResolvers`](../../advanced/extend/resolvers/programmatic-resolvers.md#additional-resolversjs) configuration options.
-
-However, you can use a local GraphQL Schema as a source by referencing a local file in the `source` field:
-
-<CodeBlock slots="heading, code" repeat="2" languages="json, ts" />
-
-#### mesh.json
-
-```json
-{
-  "meshConfig": {
-    "sources": [
-      {
-        "name": "Adobe_Commerce",
-        "handler": {
-          "graphql": {
-            "source": "./my-local-schema.ts"
-          }
-        }
-      }
-    ]
-  },
-}
-```
-
-#### file.ts
-
-```ts
-import { makeExecutableSchema } from '@graphql-tools/schema'
- 
-export default makeExecutableSchema({
-  typeDefs: /* GraphQL */ `
-    type Query {
-      foo: String
-    }
-  `,
-  resolvers: {
-    Query: {
-      foo: () => 'FOO'
-    }
-  }
-})
-```
 
 ## Config API reference
 

--- a/src/pages/mesh/basic/handlers/graphql.md
+++ b/src/pages/mesh/basic/handlers/graphql.md
@@ -84,38 +84,79 @@ The following example shows how to pass authorization headers to a GraphQL endpo
 
 Header names are automatically converted to lowercase.
 
-## Fetching SDL or introspection from CDN
+## Provide an introspection file
 
-Consider a scenario where introspection is disabled in the production environment of your GraphQL source, and you want to provide your SDL or introspection separately:
+If introspection is disabled in the production environment of your GraphQL source, and you want to provide your schema definition or introspection separately, you can use the `source` field to provide an introspection file:
 
 ```json
 {
+  "meshConfig": {
     "sources": [
-        {
-            "name": "MyGraphQLApi",
-            "handler": {
-                "graphql": {
-                    "endpoint": "https://your-service/graphql",
-                    "operationHeaders": {
-                        "Authorization": "Bearer {context.headers['GITHUB_TOKEN']}"
-                    }
-                }
-            }
+      {
+        "name": "Adobe_Commerce",
+        "handler": {
+          "graphql": {
+            "endpoint": "https://venia.magento.com/graphql",
+            "source": "./schema.graphql"
+          }
         }
+      }
     ]
+  },
 }
 ```
-
-In this case, CLI's `build` command won't save the introspection in the artifacts, so your Mesh won't start if the `source` URL is down.
 
 ## Local Schemas
 
 We recommend providing a local schema by using the [`additionalTypeDefs`](../../advanced/extend/index.md) and [`additionalResolvers`](../../advanced/extend/resolvers/programmatic-resolvers.md#additional-resolversjs) configuration options.
 
+However, you can use a local GraphQL Schema as a source by referencing a local file in the `source` field:
+
+<CodeBlock slots="heading, code" repeat="2" languages="json, ts" />
+
+#### mesh.json
+
+```json
+{
+  "meshConfig": {
+    "sources": [
+      {
+        "name": "Adobe_Commerce",
+        "handler": {
+          "graphql": {
+            "source": "./my-local-schema.ts"
+          }
+        }
+      }
+    ]
+  },
+}
+```
+
+#### file.ts
+
+```ts
+import { makeExecutableSchema } from '@graphql-tools/schema'
+ 
+export default makeExecutableSchema({
+  typeDefs: /* GraphQL */ `
+    type Query {
+      foo: String
+    }
+  `,
+  resolvers: {
+    Query: {
+      foo: () => 'FOO'
+    }
+  }
+})
+```
+
 ## Config API reference
 
 -  `endpoint` (type: `String`, required) - URL or file path for your remote GraphQL endpoint
    -  Local file types must be `.js` or `.ts`.
+-  `source` (type: `String`) - Path to the introspection file
 -  `schemaHeaders` (type: `Any`) - JSON object for adding headers to API calls for runtime schema introspection
 -  `operationHeaders` (type: `JSON`) - JSON object for adding headers to API calls for runtime operation execution
 -  `useGETForQueries` (type: `Boolean`) - An HTTP GET method for query operations

--- a/src/pages/mesh/basic/handlers/soap.md
+++ b/src/pages/mesh/basic/handlers/soap.md
@@ -17,7 +17,7 @@ The SOAP handler is experimental and should not be used in production deployment
 
 <InlineAlert variant="warning" slots="text"/>
 
-Edge meshes do not currently support SOAP handlers. If you are using SOAP handlers, you must use a legacy mesh. SOAP handlers will be available in edge meshes in the future.
+Edge meshes do not support SOAP handlers.
 
 The SOAP handler allows you to consume [SOAP](https://soapui.org) `WSDL` files and generate a remote executable schema for those services.
 

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -24,13 +24,9 @@ This release contains the following changes to API Mesh:
 
 ### Enhancements
 
-- [`beforeAll` hooks](../advanced/hooks.md) now work with [edge meshes](../basic/create-mesh.md#access-your-mesh-urls). <!-- CEXT-2904 >
-- Enhancements to performance and stability. <!-- various tickets>
-- The `source` field is now available for GraphQL handlers, allowing you to [provide an introspection file](../basic/handlers/graphql.md#provide-an-introspection-file). <!-- CEXT-3760 >
-
-### Bug fixes
-
-- Resolved an issue that caused meshes with `openapi` handlers to send the wrong content type header when working with the Adobe Commerce REST API. <!-- CEXT-3661 >
+- [`beforeAll` hooks](../advanced/hooks.md) now work with [edge meshes](../basic/create-mesh.md#access-your-mesh-urls).
+- The `source` field is now available for GraphQL handlers, allowing you to [provide an introspection file](../basic/handlers/graphql.md#provide-an-introspection-file).
+- Enhancements to performance and stability.
 
 ## October 03, 2024
 

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -18,7 +18,7 @@ import UpdateNotice from '/src/_includes/update-notice.md'
 
 The following sections list updates to API Mesh for Adobe Developer App Builder. Refer to the [Upgrade version](upgrade.md) for more information on upgrading.
 
-## October XYZXX, 2024
+## November 04, 2024
 
 This release contains the following changes to API Mesh:
 
@@ -26,6 +26,7 @@ This release contains the following changes to API Mesh:
 
 - [`beforeAll` hooks](../advanced/hooks.md) now work with [edge meshes](../basic/create-mesh.md#access-your-mesh-urls). <!-- CEXT-2904 >
 - Enhancements to performance and stability. <!-- various tickets>
+- The `source` field is now available for GraphQL handlers, allowing you to [provide an introspection file](../basic/handlers/graphql.md#provide-an-introspection-file). <!-- CEXT-3760 >
 
 ### Bug fixes
 

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -18,6 +18,19 @@ import UpdateNotice from '/src/_includes/update-notice.md'
 
 The following sections list updates to API Mesh for Adobe Developer App Builder. Refer to the [Upgrade version](upgrade.md) for more information on upgrading.
 
+## October XYZXX, 2024
+
+This release contains the following changes to API Mesh:
+
+### Enhancements
+
+- [`beforeAll` hooks](../advanced/hooks.md) now work with [edge meshes](../basic/create-mesh.md#access-your-mesh-urls). <!-- CEXT-2904 >
+- Enhancements to performance and stability. <!-- various tickets>
+
+### Bug fixes
+
+- Resolved an issue that caused meshes with `openapi` handlers to send the wrong content type header when working with the Adobe Commerce REST API. <!-- CEXT-3661 >
+
 ## October 03, 2024
 
 This release contains the following changes to API Mesh:


### PR DESCRIPTION
This PR updates the release notes and makes corresponding updates to pages that mention hooks and the GraphQL handler.

Pages affected:

- https://developer.adobe.com/graphql-mesh-gateway/mesh/release/
- https://developer.adobe.com/graphql-mesh-gateway/mesh/basic/handlers/graphql/
- https://developer.adobe.com/graphql-mesh-gateway/mesh/advanced/hooks/