### PR TITLE
Deprecate replaceField transform

### DIFF
--- a/src/pages/mesh/basic/transforms/index.md
+++ b/src/pages/mesh/basic/transforms/index.md
@@ -23,7 +23,7 @@ API Mesh currently supports the following transforms:
 -  [Rename](./rename.md)
 -  [Prefix](./prefix.md)
 -  [Filter Schema](./filter-schema.md)
--  [Replace Field](./replace-field.md)
+-  [Replace Field](./replace-field.md)(deprecated)
 -  [Type Merging](./type-merging.md)
 -  [Naming Convention](./naming-convention.md)
 -  [Hooks](../../advanced/hooks.md)
@@ -32,7 +32,6 @@ Additionally, the following transforms are available but are not fully supported
 
 -  [Encapsulate](./encapsulate.md)
 -  [Federation](./federation.md)
--  [Hoist field](./replace-field.md#scope-hoistvalue)
 
 Other transforms are not supported.
 
@@ -155,5 +154,4 @@ The following table specifies the GraphQL Mesh versions of each transform suppor
 [namingConvention](./naming-convention.md) | `0.13.22`
 [prefix](./prefix.md) | `0.12.22`
 [rename](./rename.md) | `0.14.22`
-[replaceField](./replace-field.md) | `0.4.20`
 [typeMerging](./type-merging.md) | `0.5.20`

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -111,7 +111,7 @@ The following commands will take slightly longer to complete. Consider using [lo
 
 <InlineAlert variant="info" slots="text"/>
 
-Due to compatibility limitations, certain features, such as [hooks](../advanced/hooks.md), [SOAP handlers](../basic/handlers/soap.md), and [`replaceField` transforms](../basic/transforms/replace-field.md) are not available in edge meshes. These features will be available in a future release.
+Due to compatibility limitations, certain features, such as [hooks](../advanced/hooks.md), [SOAP handlers](../basic/handlers/soap.md), and [`replaceField` transforms](../basic/transforms/replace-field.md) are not available in edge meshes.
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/mesh/release/update.md
+++ b/src/pages/mesh/release/update.md
@@ -18,7 +18,7 @@ Multiple partners are already using the updated version of API Mesh and have see
 
 <InlineAlert variant="info" slots="text"/>
 
-Due to compatibility limitations, certain features, such as [hooks](../advanced/hooks.md), [SOAP handlers](../basic/handlers/soap.md), and [`replaceField` transforms](../basic/transforms/replace-field.md) are not available in edge meshes. These features will be available in a future release.
+Due to compatibility limitations, certain features, such as [hooks](../advanced/hooks.md), [SOAP handlers](../basic/handlers/soap.md), and [`replaceField` transforms](../basic/transforms/replace-field.md) are not available in edge meshes.
 
 ## Why the change?
 


### PR DESCRIPTION
## Purpose of this pull request

This PR deprecates the replaceField transform for edge meshes and describes how you can get similar functionality out of `additionalResolvers`. 

Pages affected: 

- https://developer.adobe.com/graphql-mesh-gateway/mesh/basic/transforms/replace-field/
