### PR TITLE
Use reusable workflow for the github-pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,26 +1,20 @@
-# The workflow is based on a starter workflow https://github.com/actions/starter-workflows/blob/main/pages/gatsby.yml
 name: Deploy Gatsby site to Pages
 
 on: workflow_dispatch
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
-# Default to bash
 defaults:
   run:
     shell: bash
 
 jobs:
   call-workflow-deploy-to-pages:
-    uses: commerce-docs/commerce-testing/.github/workflows/deploy-to-pages.yml@ds_pages
-    secrets: inherit
+    uses: AdobeDocs/commerce-php/.github/workflows/deploy-to-pages_job.yml@main

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,45 +1,26 @@
----
-name: Github Pages
-on: workflow_dispatch
-permissions: {}
-jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Setup Node and Install Dependencies Action
-        uses: commerce-docs/devsite-install-action@main
-        with:
-          node-version-file: '.nvmrc'
-          cache-dependency-path: 'yarn.lock'
+# The workflow is based on a starter workflow https://github.com/actions/starter-workflows/blob/main/pages/gatsby.yml
+name: Deploy Gatsby site to Pages
 
-      - name: Build site
-        run: yarn build
-        env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
-          PREFIX_PATHS: true # works like --prefix-paths flag for 'gatsby build'
-          PATH_PREFIX: ${{ github.event.repository.name }}
-          ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_SRC }}
-          ADOBE_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT: ${{ secrets.ADOBE_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT }}
-          REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_OWNER: ${{ github.event.repository.owner.login }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          REPO_BRANCH: ${{ github.ref_name }}
-          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-          GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
-          GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
-      - name: Deploy to GH Pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages # The branch the action should deploy to.
-          folder: public # The folder the action should deploy.
-          clean: true # Automatically remove deleted files from deploy branch
-      - name: GH Pages URL
-        id: gh-pages-url
-        run: |
-          echo "View GH-Pages: $(https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }})"
+on: workflow_dispatch
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  call-workflow-deploy-to-pages:
+    uses: commerce-docs/commerce-testing/.github/workflows/deploy-to-pages.yml@ds_pages
+    secrets: inherit


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) improves the github-pages workflow via reusable workflow implemented in AdobeDocs/commerce-php/pull/350.

Green run see [here](https://github.com/commerce-docs/graphql-mesh-gateway/actions/runs/13528136398).