### PR TITLE
CLI and encoding updates

### DIFF
--- a/src/_includes/update-notice.md
+++ b/src/_includes/update-notice.md
@@ -5,4 +5,4 @@
 
 [Update the API Mesh CLI](../pages/mesh/basic/index.md#install-the-aio-cli) to the latest version to avoid encoding issues.
 
-[Update CLI](../pages/mesh/basic/index.md#install-the-aio-cli)
+[Update CLI](src/pages/mesh/basic/index.md#install-the-aio-cli)

--- a/src/_includes/update-notice.md
+++ b/src/_includes/update-notice.md
@@ -1,8 +1,6 @@
 
 <AnnouncementBlock slots="heading, text, button" />
 
-### Update notice for legacy mesh URLs
+### Update to the latest CLI version
 
-API Mesh now runs at the edge, and legacy mesh URLs are no longer available. Click the **Update notice** to find more information on how to update your mesh:
-
-[Update notice](/src/pages/mesh/release/update.md)
+[Update the API Mesh CLI](../pages/mesh/basic/index.md#install-the-aio-cli) to the latest version to avoid encoding issues.

--- a/src/_includes/update-notice.md
+++ b/src/_includes/update-notice.md
@@ -4,3 +4,5 @@
 ### Update to the latest CLI version
 
 [Update the API Mesh CLI](../pages/mesh/basic/index.md#install-the-aio-cli) to the latest version to avoid encoding issues.
+
+[Update CLI](../pages/mesh/basic/index.md#install-the-aio-cli)

--- a/src/pages/mesh/basic/work-with-mesh.md
+++ b/src/pages/mesh/basic/work-with-mesh.md
@@ -239,3 +239,17 @@ If your schema contains sensitive information, you can prevent introspection and
   }
 }
 ```
+
+## URL encoding
+
+API Mesh only supports single-encoded URL parameters. Double-encoded and subsequent requests are not supported. Refer to the following examples for more information.
+
+**Accepted requests**:
+
+`/organizations/1234567890%40AdobeOrg/projects/0987654321/workspaces/3210987654321/meshes/12a3b4c5-6d78-4012-3456-7e890fa1bcde`
+
+`/organizations/1234567890@AdobeOrg/projects/0987654321/workspaces/3210987654321/meshes/12a3b4c5-6d78-4012-3456-7e890fa1bcde`
+
+**Unaccepted requests**:
+
+`/organizations/1234567890%2540AdobeOrg/projects/0987654321/workspaces/3210987654321/meshes/12a3b4c5-6d78-4012-3456-7e890fa1bcde`


### PR DESCRIPTION
This PR repurposes the existing notice that tells users about the migration to edge meshes, and instead notifies users to update their CLI to the latest version.

It also adds guidance to the acceptable level of encoding in URLs provided through a mesh.