### PR TITLE
adding links to samples repo

### DIFF
--- a/src/_includes/update-notice.md
+++ b/src/_includes/update-notice.md
@@ -3,6 +3,6 @@
 
 ### Update to the latest CLI version
 
-[Update the API Mesh CLI](../pages/mesh/basic/index.md#install-the-aio-cli) to the latest version to avoid encoding issues.
+[Update the API Mesh CLI](../pages/mesh/release/upgrade.md#software-updates) to the latest version to avoid encoding issues.
 
-[Update CLI](src/pages/mesh/basic/index.md#install-the-aio-cli)
+[Update CLI](src/pages/mesh/release/upgrade.md#software-updates)

--- a/src/data/navigation/sections/mesh.js
+++ b/src/data/navigation/sections/mesh.js
@@ -246,8 +246,13 @@ module.exports = [
                 EventTarget: "_blank"
             },
             {
-                title: "Understanding Extensibility",
+                title: "Understanding extensibility",
                 path: "https://developer.adobe.com/commerce/extensibility/app-development/examples/",
+                EventTarget: "_blank"
+            },
+            {
+                title: "Commerce code samples",
+                path: "https://github.com/adobe/adobe-commerce-samples/tree/main/api-mesh",
                 EventTarget: "_blank"
             },
             {

--- a/src/pages/mesh/advanced/extend/index.md
+++ b/src/pages/mesh/advanced/extend/index.md
@@ -16,6 +16,11 @@ This topic describes how to use multiple APIs. Your mesh can merge different dat
 
 In addition to `@apollo/gateway`, API Mesh supports subscriptions out-of-box.
 
+Refer to the following custom resolver examples for more information:
+
+- [Add a custom field](https://github.com/adobe/adobe-commerce-samples/tree/main/api-mesh/custom-field)
+- [Mock a field](https://github.com/adobe/adobe-commerce-samples/tree/main/api-mesh/mock-response)
+
 [Learn more key differences between Schema Stitching and Apollo Federation](https://product.voxmedia.com/2020/11/2/21494865/to-federate-or-stitch-a-graphql-gateway-revisited)
 
 ## Extending GraphQL Schema with `additionalTypeDefs`

--- a/src/pages/mesh/basic/create-mesh.md
+++ b/src/pages/mesh/basic/create-mesh.md
@@ -178,6 +178,8 @@ You can also create a mesh automatically when [bootstrapping a new app through t
 
 The following example adds both an Adobe Commerce instance (with Catalog Service enabled) and an Adobe Experience Manager instance to the mesh. The GraphQL endpoints for Commerce and Catalog Service are different, so you must configure them separately.
 
+For another example, refer to the [API Mesh multiple sources sample](https://github.com/adobe/adobe-commerce-samples/tree/main/api-mesh/commerce-and-catalog).
+
 ```json
 {
   "meshConfig": {

--- a/src/pages/mesh/basic/work-with-mesh.md
+++ b/src/pages/mesh/basic/work-with-mesh.md
@@ -217,6 +217,8 @@ When you query a mesh using chained mutations, the mesh makes a separate call to
 
 These mutations are executed sequentially, calling one source after the other. When you call a source directly, it will only need one API call, but it will execute the batch mutations sequentially by calling their respective resolvers. These calls are more overt in API Mesh, because they are made by a network call, instead of an internal call. This means you will see multiple calls for chained mutations.
 
+For more information on chain mutations, refer to the [chain mutation code samples](https://github.com/adobe/adobe-commerce-samples/tree/main/api-mesh/chain-mutations).
+
 ## Disable introspection
 
 If your schema contains sensitive information, you can prevent introspection and disable auto-completion by adding the `disableIntrospection` configuration option to your mesh. `disableIntrospection` defaults to `false`. To disable introspection, set it to `true`.

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -24,7 +24,7 @@ This release contains the following changes to API Mesh:
 
 ### Bug fixes
 
-- Resolved an encoding issue that could cause problems when interacting with a mesh. Update your CLI to the latest version, if you experience similar issues.
+- Resolved an encoding issue that could cause problems when interacting with a mesh. [Update your CLI to the latest version](./upgrade.md#software-updates), if you experience similar issues.
 - Resolved an issue that prevented certain `additionalResolvers` from functioning correctly when using [local development](../advanced/developer-tools.md).
 
 ## March 03, 2025


### PR DESCRIPTION
This PR better integrates links to the [Commerce Samples](https://github.com/adobe/adobe-commerce-samples/) repo by adding an entry to the TOC, as well as linking to specific examples as they are relevant.