### PR TITLE
`_includes` links

### DIFF
--- a/src/_includes/update-notice.md
+++ b/src/_includes/update-notice.md
@@ -3,6 +3,6 @@
 
 ### Update to the latest CLI version
 
-[Update the API Mesh CLI](https://developer.adobe.com/graphql-mesh-gateway/mesh/release/upgrade/#software-updates) to the latest version to avoid encoding issues.
+[Update the API Mesh CLI](src/pages/mesh/release/upgrade.md#software-updates) to the latest version to avoid encoding issues.
 
-[Update CLI](https://developer.adobe.com/graphql-mesh-gateway/mesh/release/upgrade/#software-updates)
+[Update CLI](src/pages/mesh/release/upgrade.md#software-updates)

--- a/src/_includes/update-notice.md
+++ b/src/_includes/update-notice.md
@@ -3,6 +3,6 @@
 
 ### Update to the latest CLI version
 
-[Update the API Mesh CLI](src/pages/mesh/release/upgrade.md#software-updates) to the latest version to avoid encoding issues.
+[Update the API Mesh CLI](/src/pages/mesh/release/upgrade.md#software-updates) to the latest version to avoid encoding issues.
 
-[Update CLI](src/pages/mesh/release/upgrade.md#software-updates)
+[Update CLI](/src/pages/mesh/release/upgrade.md#software-updates)


### PR DESCRIPTION
This PR changes the links to the correct format for `_includes` repo links, which must be prepended by a forward slash (`/`). This change prevents current `http` links from opening in a new window.

The links at the top of each staged page below should work correctly.

- https://adobedocs.github.io/graphql-mesh-gateway/
- https://adobedocs.github.io/graphql-mesh-gateway/mesh/
- https://adobedocs.github.io/graphql-mesh-gateway/mesh/release/
