### PR TITLE
Fix yarn dev

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -23,7 +23,7 @@ export const onRouteUpdate = ({ location, prevLocation }) => {
   if (isBrowser) {
     function watchAndFireAnalytics() {
       // eslint-disable-next-line no-undef
-      if (typeof window._satellite !== 'undefined') {
+      if (typeof window._satellite !== 'undefined' && typeof window._satellite.track === 'function') {
         // eslint-disable-next-line no-undef
         _satellite.track('state',
           {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes `yarn dev` error:
```
Error in function watchAndFireAnalytics in ./gatsby-browser.js:48
_satellite.track is not a function
```

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- none
