### PR TITLE
adding .graphql to files array

### DIFF
--- a/src/pages/mesh/advanced/developer-tools.md
+++ b/src/pages/mesh/advanced/developer-tools.md
@@ -151,6 +151,10 @@ In addition to [qualifying the `content` of a file manually](../basic/handlers/i
 
 The following example references the `requestParams.json` file. When this mesh is created or updated, the contents of that file are automatically minified, stringified, and added to the `files` array.
 
+<InlineAlert variant="info" slots="text"/>
+
+The files array supports `.js`, `.ts`, and `.graphql` file formats.
+
 ```json
 {
   "meshConfig": {

--- a/src/pages/mesh/basic/handlers/graphql.md
+++ b/src/pages/mesh/basic/handlers/graphql.md
@@ -137,7 +137,7 @@ We recommend providing a local schema by using the [`additionalTypeDefs`](../../
 ## Config API reference
 
 -  `endpoint` (type: `String`, required) - URL or file path for your remote GraphQL endpoint
-   -  Local file types must be `.js` or `.ts`.
+   -  Local file types must be `.js`, `.ts`, or `.graphql`.
 -  `source` (type: `String`) - Path to the introspection file
 -  `schemaHeaders` (type: `Any`) - JSON object for adding headers to API calls for runtime schema introspection
 -  `operationHeaders` (type: `JSON`) - JSON object for adding headers to API calls for runtime operation execution

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -28,6 +28,14 @@ aio plugins:install @adobe/aio-cli-plugin-api-mesh
 
 This release contains the following changes to API Mesh:
 
+### Enhancements
+
+- Added support for `.graphql` files in the [`files` array](../advanced/developer-tools.md#reference-local-files-in-handlers).
+
+## June 24, 2025
+
+This release contains the following changes to API Mesh:
+
 ### Bug fixes
 
 - Fixed an error that could occur when using the `aio api-mesh:run` command with unreferenced files in your mesh configuration.

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -30,7 +30,7 @@ This release contains the following changes to API Mesh:
 
 ### Enhancements
 
-- Added support for `.graphql` files in the [`files` array](../advanced/developer-tools.md#reference-local-files-in-handlers).
+- Added support for `.graphql` files in the [`files` array](../advanced/developer-tools.md#reference-files-directly).
 
 ## June 24, 2025
 


### PR DESCRIPTION
This PR adds support for the `.graphql` file type in the `files` array.