### PR TITLE
january bug fix - API Mesh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ local-test.yml
 # yalc
 .yalc
 yalc.lock
+
+# cursor
+.cursor

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -44,7 +44,6 @@ This release contains the following changes to API Mesh:
 
 - Resolved an issue where the Developer Console UI incorrectly displayed a status of "Provisioning" for successfully deployed meshes.
 
-
 ## December 03, 2025
 
 This release contains the following changes to API Mesh:

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -36,6 +36,15 @@ aio plugins:uninstall @adobe/aio-cli-plugin-api-mesh
 aio plugins install @adobe/aio-cli-plugin-api-mesh
 ```
 
+## January 07, 2026
+
+This release contains the following changes to API Mesh:
+
+### Bug fixes
+
+- Resolved an issue where the Developer Console UI incorrectly displayed a status of "Provisioning" for successfully deployed meshes.
+
+
 ## December 03, 2025
 
 This release contains the following changes to API Mesh:


### PR DESCRIPTION
This PR adds a bug fix to the [Release Notes](https://developer.adobe.com/graphql-mesh-gateway/mesh/release/) page.

It also adds `.cursor` to the `.gitignore` file.