### PR TITLE
remove experimental note - API Mesh

### DIFF
--- a/src/pages/mesh/advanced/logging.md
+++ b/src/pages/mesh/advanced/logging.md
@@ -64,10 +64,6 @@ aio api-mesh:log-get-bulk --past 30 --filename mesh_logs.csv
 
 ## Log forwarding
 
-<InlineAlert variant="warning" slots="text"/>
-
-Log forwarding is an experimental feature and may not function as expected.
-
 Log forwarding allows you to forward logs from API Mesh to a user-owned third-party service.
 
 Using a third-party service allows you to control throttling, log size limits, and log retention policies.


### PR DESCRIPTION
This PR removes the "experimental" warning from log forwarding. Log forwarding is currently stable and the note is confusing users. 