### PR TITLE
Fix cacheControl example - API Mesh

### DIFF
--- a/src/pages/mesh/advanced/caching/cache-control-headers.md
+++ b/src/pages/mesh/advanced/caching/cache-control-headers.md
@@ -112,11 +112,11 @@ To configure a default cache-control directive, add a `cacheControl` key-value p
         "handler": {
           "openapi": {
             "source": "<your_endpoint>"
-          },
-          "responseConfig": {
-            "cache": {
-              "cacheControl": "public, max-age=100"
-            }
+          }
+        },
+        "responseConfig": {
+          "cache": {
+            "cacheControl": "public, max-age=100"
           }
         }
       },


### PR DESCRIPTION
This PR closes https://github.com/AdobeDocs/graphql-mesh-gateway/issues/372 by fixing the level of the `responseConfig` object, which should be under `sources`, not the `handler`.