### PR TITLE
Add mesh support for .graphql attachments

### DIFF
--- a/src/pages/mesh/advanced/developer-tools.md
+++ b/src/pages/mesh/advanced/developer-tools.md
@@ -144,7 +144,8 @@ You can confirm that your variables were updated successfully by running the [`a
 
 In addition to [qualifying the `content` of a file manually](../basic/handlers/index.md#reference-local-files-in-handlers), you can directly reference a file in your mesh for automatic conversion. The following restrictions apply:
 
-- Only `JS` and `JSON` file formats are allowed.
+- Only `JS` and `JSON` file formats are allowed for handler sources.
+- `.graphql` files are supported in [`additionalTypeDefs`](./extend/index.md#using-graphql-files-with-additionaltypedefs), the `files` array, and the GraphQL handler's `source` field.
 - The referenced file's path must be less than 25 characters.
 - The referenced file must be in the same directory as the mesh file that references it.
 - The file cannot be in the `~` or `home` directory.

--- a/src/pages/mesh/advanced/extend/index.md
+++ b/src/pages/mesh/advanced/extend/index.md
@@ -47,6 +47,47 @@ For example, if we have the StackExchange API in our Mesh configuration:
 
 We might want to add a new field under the `Query` root type named `viewsInPastMonth`, but we will need a resolver for this field.
 
+### Using `.graphql` files with `additionalTypeDefs`
+
+Instead of providing type definitions as inline strings, you can reference `.graphql` files. This is especially useful when your type definitions are long or complex. When you reference `.graphql` files in `additionalTypeDefs`, they are automatically imported.
+
+```json
+{
+  "sources": [
+    {
+      "name": "StackExchange",
+      "handler": {
+        "openapi": {
+          "source": "https://raw.githubusercontent.com/grokify/api-specs/master/stackexchange/stackexchange-api-v2.2_openapi-v3.0.yaml"
+        }
+      }
+    }
+  ],
+  "additionalTypeDefs": ["./custom-types.graphql"],
+  "additionalResolvers": ["./resolvers.js"]
+}
+```
+
+Where `custom-types.graphql` contains:
+
+```graphql
+extend type Query {
+  listQuestionsFromStackOverflow(first: Int!): [Question]
+}
+```
+
+You can also reference multiple `.graphql` files:
+
+```json
+{
+  "additionalTypeDefs": ["./announcements.graphql", "./cart.graphql"],
+  "additionalResolvers": [
+    "./announcements-resolver.js",
+    "./cart-resolver.js"
+  ]
+}
+```
+
 ## Merging types from different sources (Type Merging)
 
 Imagine you have two different services, `Books` and `Authors`, which are exposing the following schemas:

--- a/src/pages/mesh/advanced/extend/index.md
+++ b/src/pages/mesh/advanced/extend/index.md
@@ -49,7 +49,7 @@ We might want to add a new field under the `Query` root type named `viewsInPastM
 
 ### Using `.graphql` files with `additionalTypeDefs`
 
-Instead of providing type definitions as inline strings, you can reference `.graphql` files. This is especially useful when your type definitions are long or complex. When you reference `.graphql` files in `additionalTypeDefs`, they are automatically imported.
+Instead of providing type definitions as inline strings, you can reference `.graphql` files, which is useful when your type definitions are long or complex. When you reference `.graphql` files in `additionalTypeDefs`, they are automatically imported.
 
 ```json
 {

--- a/src/pages/mesh/release/index.md
+++ b/src/pages/mesh/release/index.md
@@ -36,6 +36,14 @@ aio plugins:uninstall @adobe/aio-cli-plugin-api-mesh
 aio plugins install @adobe/aio-cli-plugin-api-mesh
 ```
 
+## March 30, 2026
+
+This release contains the following changes to API Mesh:
+
+### Enhancements
+
+- Added support for `.graphql` files in [`additionalTypeDefs`](../advanced/extend/index.md), allowing you to reference `.graphql` files instead of using inline type definition strings.
+
 ## March 23, 2026
 
 This release contains the following changes to API Mesh:


### PR DESCRIPTION
This PR adds support for `.graphql` attachments when using additionalTypeDefs.