### PR TITLE
Add links to Slack channel

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -70,5 +70,5 @@
         - [Video tutorials](https://experienceleague.adobe.com/docs/commerce-learn/api-mesh/getting-started-api-mesh.html)
         - [Understanding extensibility](https://developer.adobe.com/commerce/extensibility/app-development/examples/)
         - [Commerce code samples](https://github.com/adobe/adobe-commerce-samples/tree/main/api-mesh)
-        - [Slack](https://magentocommeng.slack.com/archives/C08TH60U290)
+        - [Public Slack Channel](https://magentocommeng.slack.com/archives/C08TH60U290)
         - [Contact support](https://experienceleague.adobe.com/home?support-tab=home#support)

--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -70,4 +70,5 @@
         - [Video tutorials](https://experienceleague.adobe.com/docs/commerce-learn/api-mesh/getting-started-api-mesh.html)
         - [Understanding extensibility](https://developer.adobe.com/commerce/extensibility/app-development/examples/)
         - [Commerce code samples](https://github.com/adobe/adobe-commerce-samples/tree/main/api-mesh)
+        - [Slack](https://magentocommeng.slack.com/archives/C08TH60U290)
         - [Contact support](https://experienceleague.adobe.com/home?support-tab=home#support)

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -56,6 +56,10 @@ Is a complete framework that enables enterprise developers to build and deploy c
 
 Makes Commerce transactional data available to App Builder using Adobe I/O. You can define the events to transmit data each time an event triggers, or only under circumstances defined within configuration rules.
 
+## Join the conversation
+
+Join the [#commerce-api-mesh-community](https://magentocommeng.slack.com/archives/C08TH60U290) Slack channel to ask questions, share your work, and connect with other developers interested in API Mesh.
+
 ## Contributing to this documentation
 
 We encourage you to participate in our open documentation initiative. If you have suggestions, corrections, additions, or deletions for this documentation, check out the source on [GitHub](https://github.com/AdobeDocs/graphql-mesh-gateway) and open a pull request.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a link to the new `#commerce-api-mesh-community` Slack channel so developers have a direct way to ask questions, share their work, and connect with the API Mesh community. The link is surfaced in two places:

- A new **Join the conversation** section on the home page.
- A **Slack** entry under **Additional resources** in the left navigation (`config.md`).

## Affected pages

- https://developer.adobe.com/graphql-mesh-gateway

## Links to Magento Open Source code

- N/A